### PR TITLE
Remove field_init_shorthand feature flag.

### DIFF
--- a/chalk-rust-parse/src/lib.rs
+++ b/chalk-rust-parse/src/lib.rs
@@ -1,5 +1,4 @@
 #![recursion_limit = "1024"]
-#![feature(field_init_shorthand)]
 
 #[macro_use]
 extern crate error_chain;


### PR DESCRIPTION
This feature flag is no longer necessary on nightly.