### PR TITLE
Separate Program from ProgramEnvironment.

### DIFF
--- a/chalk-rust/src/solve/environment.rs
+++ b/chalk-rust/src/solve/environment.rs
@@ -29,7 +29,7 @@ impl Environment {
         Arc::new(env)
     }
 
-    pub fn elaborated_clauses(&self, program: &Program) -> impl Iterator<Item = WhereClause> {
+    pub fn elaborated_clauses(&self, program: &ProgramEnvironment) -> impl Iterator<Item = WhereClause> {
         let mut set = HashSet::new();
         set.extend(self.clauses.iter().cloned());
 

--- a/chalk-rust/src/solve/fulfill.rs
+++ b/chalk-rust/src/solve/fulfill.rs
@@ -23,7 +23,7 @@ impl<'s> Fulfill<'s> {
         Fulfill { solver, infer, obligations: vec![], constraints: HashSet::new() }
     }
 
-    pub fn program(&self) -> Arc<Program> {
+    pub fn program(&self) -> Arc<ProgramEnvironment> {
         self.solver.program.clone()
     }
 

--- a/chalk-rust/src/solve/solver/mod.rs
+++ b/chalk-rust/src/solve/solver/mod.rs
@@ -13,13 +13,13 @@ use std::sync::Arc;
 use super::*;
 
 pub struct Solver {
-    pub(super) program: Arc<Program>,
+    pub(super) program: Arc<ProgramEnvironment>,
     overflow_depth: usize,
     stack: Vec<Query<InEnvironment<WhereClauseGoal>>>,
 }
 
 impl Solver {
-    pub fn new(program: &Arc<Program>, overflow_depth: usize) -> Self {
+    pub fn new(program: &Arc<ProgramEnvironment>, overflow_depth: usize) -> Self {
         Solver { program: program.clone(), stack: vec![], overflow_depth, }
     }
 

--- a/chalk-rust/src/solve/test.rs
+++ b/chalk-rust/src/solve/test.rs
@@ -27,6 +27,7 @@ fn solve_goal(program_text: &str,
     assert!(program_text.starts_with("{"));
     assert!(program_text.ends_with("}"));
     let program = Arc::new(parse_and_lower_program(&program_text[1..program_text.len()-1]).unwrap());
+    let env = Arc::new(program.environment());
     ir::set_current_program(&program, || {
         for (goal_text, expected) in goals {
             println!("----------------------------------------------------------------------");
@@ -39,7 +40,7 @@ fn solve_goal(program_text: &str,
             // tests don't require a higher one.
             let overflow_depth = 3;
 
-            let mut solver = Solver::new(&program, overflow_depth);
+            let mut solver = Solver::new(&env, overflow_depth);
             let result = match Prove::new(&mut solver, goal).solve() {
                 Ok(v) => format!("{:#?}", v),
                 Err(e) => format!("{}", e),


### PR DESCRIPTION
Closes #19. I took a slightly different approach from your suggestion.

ir::Program and ProgramEnvironment are distinct types with no ownership
relationship, but instead of lowering returning a tuple, ir::Program
has a method to construct a ProgramEnvironment.

In addition to the trait_data, the associated_type_data also needs to
be cloned over, and the `split_projection` method is duplicated for
both types, because that method is invoked in `elaborated_clauses`.

It seems like once we have a new way of solving #12, ProgramEnvironment
would just be a set of ProgramClauses, and that would be the whole
context necessary for the solver to run.