### PR TITLE
Separate query binders into three sets of indexes.

### DIFF
--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -492,7 +492,7 @@ pub struct ProgramClauseImplication {
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Query<T> {
     pub value: T,
-    pub binders: Vec<ParameterKind<UniverseIndex>>,
+    pub binders: QueryBinders,
 }
 
 impl<T> Query<T> {
@@ -501,6 +501,13 @@ impl<T> Query<T> {
     {
         Query { value: op(self.value), binders: self.binders }
     }
+}
+
+#[derive(Default, Clone, Debug, PartialEq, Eq, Hash)]
+pub struct QueryBinders {
+    pub tys: Vec<UniverseIndex>,
+    pub lifetimes: Vec<UniverseIndex>,
+    pub krates: Vec<UniverseIndex>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -503,11 +503,21 @@ impl<T> Query<T> {
     }
 }
 
-#[derive(Default, Clone, Debug, PartialEq, Eq, Hash)]
-pub struct QueryBinders {
-    pub tys: Vec<UniverseIndex>,
-    pub lifetimes: Vec<UniverseIndex>,
-    pub krates: Vec<UniverseIndex>,
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct QueryBinders<T = UniverseIndex, L = T, C = T> {
+    pub tys: Vec<T>,
+    pub lifetimes: Vec<L>,
+    pub krates: Vec<C>,
+}
+
+impl<T, L, C> Default for QueryBinders<T, L, C> {
+    fn default() -> Self {
+        Self {
+            tys: vec![],
+            lifetimes: vec![],
+            krates: vec![],
+        }
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]

--- a/src/solve/fulfill.rs
+++ b/src/solve/fulfill.rs
@@ -245,9 +245,10 @@ impl<'s> Fulfill<'s> {
 
         debug!("fulfill::solve_one: new_type_info={}", new_type_info);
 
+
         if new_type_info || !solution.refined_goal.value.constraints.is_empty() {
             let Constrained { constraints, value: refined_goal } =
-                self.instantiate(solution.refined_goal.binders.iter().cloned(),
+                self.instantiate(universes_from_binders(&solution.refined_goal.binders),
                                  &solution.refined_goal.value);
 
             debug!("fulfill::solve_one: adding constraints {:?}", constraints);
@@ -263,4 +264,11 @@ impl<'s> Fulfill<'s> {
 
         Ok(solution.successful)
     }
+}
+
+fn universes_from_binders<'a>(binders: &'a QueryBinders) -> impl Iterator<Item = ParameterKind<UniverseIndex>> + 'a {
+    let tys = binders.tys.iter().cloned().map(ParameterKind::Ty);
+    let lifetimes = binders.lifetimes.iter().cloned().map(ParameterKind::Lifetime);
+    let krates = binders.krates.iter().cloned().map(ParameterKind::Krate);
+    tys.chain(lifetimes).chain(krates)
 }

--- a/src/solve/infer/instantiate.rs
+++ b/src/solve/infer/instantiate.rs
@@ -1,4 +1,5 @@
 use fold::*;
+use ir::QueryBinders;
 use std::fmt::Debug;
 
 use super::*;
@@ -11,9 +12,14 @@ impl InferenceTable {
               U: IntoIterator<Item = ParameterKind<UniverseIndex>>
     {
         debug!("instantiate(arg={:?})", arg);
-        let vars: Vec<_> = universes.into_iter()
-            .map(|u| self.new_parameter_variable(u))
-            .collect();
+        let mut vars = QueryBinders::default();
+        for var in universes.into_iter().map(|u| self.new_parameter_variable(u)) {
+            match var {
+                ParameterKind::Ty(ty)       => vars.tys.push(ty),
+                ParameterKind::Lifetime(l)  => vars.lifetimes.push(l),
+                ParameterKind::Krate(krate) => vars.krates.push(krate),
+            }
+        }
         debug!("instantiate: vars={:?}", vars);
         let mut instantiator = Instantiator { vars: vars };
         arg.fold_with(&mut instantiator, 0).expect("")
@@ -21,7 +27,7 @@ impl InferenceTable {
 }
 
 struct Instantiator {
-    vars: Vec<ParameterInferenceVariable>,
+    vars: QueryBinders<TyInferenceVariable, LifetimeInferenceVariable, KrateInferenceVariable>,
 }
 
 /// Folder: when we encounter a free variable (of any kind) with index
@@ -31,26 +37,26 @@ struct Instantiator {
 /// instantiating.
 impl Folder for Instantiator {
     fn fold_free_var(&mut self, depth: usize, binders: usize) -> Result<Ty> {
-        if depth < self.vars.len() {
-            Ok(self.vars[depth].as_ref().ty().unwrap().to_ty().up_shift(binders))
+        if depth < self.vars.tys.len() {
+            Ok(self.vars.tys[depth].to_ty().up_shift(binders))
         } else {
-            Ok(Ty::Var(depth + binders - self.vars.len())) // see comment above
+            Ok(Ty::Var(depth + binders - self.vars.tys.len())) // see comment above
         }
     }
 
     fn fold_free_lifetime_var(&mut self, depth: usize, binders: usize) -> Result<Lifetime> {
-        if depth < self.vars.len() {
-            Ok(self.vars[depth].as_ref().lifetime().unwrap().to_lifetime().up_shift(binders))
+        if depth < self.vars.lifetimes.len() {
+            Ok(self.vars.lifetimes[depth].to_lifetime().up_shift(binders))
         } else {
-            Ok(Lifetime::Var(depth + binders - self.vars.len())) // see comment above
+            Ok(Lifetime::Var(depth + binders - self.vars.lifetimes.len())) // see comment above
         }
     }
 
     fn fold_free_krate_var(&mut self, depth: usize, binders: usize) -> Result<Krate> {
-        if depth < self.vars.len() {
-            Ok(self.vars[depth].as_ref().krate().unwrap().to_krate().up_shift(binders))
+        if depth < self.vars.krates.len() {
+            Ok(self.vars.krates[depth].to_krate().up_shift(binders))
         } else {
-            Ok(Krate::Var(depth + binders - self.vars.len())) // see comment above
+            Ok(Krate::Var(depth + binders - self.vars.krates.len())) // see comment above
         }
     }
 }

--- a/src/solve/infer/mod.rs
+++ b/src/solve/infer/mod.rs
@@ -37,6 +37,14 @@ impl InferenceTable {
         }
     }
 
+    pub fn new_from_binders(binders: &QueryBinders) -> Self {
+        let mut table = InferenceTable::new();
+        for &ui in &binders.tys { table.new_variable(ui); }
+        for &ui in &binders.lifetimes { table.new_lifetime_variable(ui); }
+        for &ui in &binders.krates { table.new_krate_variable(ui); }
+        table
+    }
+
     pub fn new_with_vars(vars: &[ParameterKind<UniverseIndex>]) -> Self {
         let mut table = InferenceTable::new();
         for &ui in vars {

--- a/src/solve/infer/query.rs
+++ b/src/solve/infer/query.rs
@@ -29,7 +29,7 @@ impl InferenceTable {
         debug!("make_query({:#?})", value);
         let mut q = Querifier {
             table: self,
-            free_vars: Vec::new(),
+            free_vars: QueryBinders::default(),
         };
         let r = value.fold_with(&mut q, 0).unwrap();
         Query {
@@ -41,48 +41,51 @@ impl InferenceTable {
 
 struct Querifier<'q> {
     table: &'q mut InferenceTable,
-    free_vars: Vec<ParameterInferenceVariable>,
+    free_vars: QueryBinders<TyInferenceVariable, LifetimeInferenceVariable, KrateInferenceVariable>,
 }
 
 impl<'q> Querifier<'q> {
     fn into_binders(self) -> QueryBinders {
         let Querifier { table, free_vars } = self;
         let mut binders = QueryBinders::default();
-        for p_v in free_vars {
-            match p_v {
-                ParameterKind::Ty(v) => {
-                    debug_assert!(table.ty_unify.find(v) == v);
-                    match table.ty_unify.probe_value(v) {
-                        InferenceValue::Unbound(ui) => binders.tys.push(ui),
-                        InferenceValue::Bound(_) => panic!("free var now bound"),
-                    }
-                }
-                ParameterKind::Lifetime(v) => {
-                    match table.lifetime_unify.probe_value(v) {
-                        InferenceValue::Unbound(ui) => binders.lifetimes.push(ui),
-                        InferenceValue::Bound(_) => panic!("free var now bound"),
-                    }
-                }
+        for ty in free_vars.tys {
+            debug_assert!(table.ty_unify.find(ty) == ty);
+            match table.ty_unify.probe_value(ty) {
+                InferenceValue::Unbound(ui) => binders.tys.push(ui),
+                InferenceValue::Bound(_) => panic!("free var now bound"),
+            }
+        }
 
-                ParameterKind::Krate(c) => {
-                    match table.krate_unify.probe_value(c) {
-                        InferenceValue::Unbound(ui) => binders.krates.push(ui),
-                        InferenceValue::Bound(_) => panic!("free var now bound"),
-                    }
-                }
+        for lifetime in free_vars.lifetimes {
+            match table.lifetime_unify.probe_value(lifetime) {
+                InferenceValue::Unbound(ui) => binders.lifetimes.push(ui),
+                InferenceValue::Bound(_) => panic!("free var now bound"),
+            }
+        }
+        for krate in free_vars.krates {
+            match table.krate_unify.probe_value(krate) {
+                InferenceValue::Unbound(ui) => binders.krates.push(ui),
+                InferenceValue::Bound(_) => panic!("free var now bound"),
             }
         }
         binders
     }
 
     fn add(&mut self, free_var: ParameterInferenceVariable) -> usize {
-        match self.free_vars.iter().position(|&v| v == free_var) {
-            Some(i) => i,
-            None => {
-                let next_index = self.free_vars.len();
-                self.free_vars.push(free_var);
-                next_index
+        fn find_idx<T: Eq>(vars: &mut Vec<T>, free_var: T) -> usize {
+            match vars.iter().position(|&v| v == free_var) {
+                Some(i) => i,
+                None    => {
+                    let next_index = vars.len();
+                    vars.push(free_var);
+                    next_index
+                }
             }
+        }
+        match free_var {
+            ParameterKind::Ty(t)        => find_idx(&mut self.free_vars.tys, t),
+            ParameterKind::Lifetime(l)  => find_idx(&mut self.free_vars.lifetimes, l),
+            ParameterKind::Krate(k)     => find_idx(&mut self.free_vars.krates, k),
         }
     }
 }

--- a/src/solve/infer/query.rs
+++ b/src/solve/infer/query.rs
@@ -72,7 +72,7 @@ impl<'q> Querifier<'q> {
     }
 
     fn add(&mut self, free_var: ParameterInferenceVariable) -> usize {
-        fn find_idx<T: Eq>(vars: &mut Vec<T>, free_var: T) -> usize {
+        fn find_idx<T: Copy + Eq>(vars: &mut Vec<T>, free_var: T) -> usize {
             match vars.iter().position(|&v| v == free_var) {
                 Some(i) => i,
                 None    => {

--- a/src/solve/infer/test.rs
+++ b/src/solve/infer/test.rs
@@ -207,7 +207,10 @@ fn quantify_simple() {
         table.make_query(&ty!(apply (item 0) (var 2) (var 1) (var 0))),
         Query {
             value: ty!(apply (item 0) (var 0) (var 1) (var 2)),
-            binders: vec![ParameterKind::Ty(U2), ParameterKind::Ty(U1), ParameterKind::Ty(U0)],
+            binders: QueryBinders {
+                tys: vec![U2, U1, U0],
+                ..QueryBinders::default()
+            },
         });
 }
 
@@ -233,6 +236,9 @@ fn quantify_bound() {
         table.make_query(&ty!(apply (item 0) (expr v2b) (expr v2a) (expr v1) (expr v0))),
         Query {
             value: ty!(apply (item 0) (apply (item 1) (var 0) (var 1)) (var 2) (var 0) (var 1)),
-            binders: vec![ParameterKind::Ty(U1), ParameterKind::Ty(U0), ParameterKind::Ty(U2)],
+            binders: QueryBinders {
+                tys: vec![U1, U0, U2],
+                ..QueryBinders::default()
+            },
         });
 }

--- a/src/solve/match_clause.rs
+++ b/src/solve/match_clause.rs
@@ -23,7 +23,7 @@ impl<'s, G> MatchClause<'s, G>
                clause: &'s WhereClause)
                -> Self {
         let InEnvironment { ref environment, ref goal } = q.value;
-        let infer = InferenceTable::new_with_vars(&q.binders);
+        let infer = InferenceTable::new_from_binders(&q.binders);
         let environment = environment.clone();
         let fulfill = Fulfill::new(solver, infer);
         MatchClause { fulfill, environment, goal, clause }

--- a/src/solve/match_program_clause.rs
+++ b/src/solve/match_program_clause.rs
@@ -23,7 +23,7 @@ impl<'s, G> MatchProgramClause<'s, G>
                program_clause: &'s ProgramClause)
                -> Self {
         let InEnvironment { ref environment, ref goal } = q.value;
-        let infer = InferenceTable::new_with_vars(&q.binders);
+        let infer = InferenceTable::new_from_binders(&q.binders);
         let environment = environment.clone();
         let mut fulfill = Fulfill::new(solver, infer);
 

--- a/src/solve/normalize_application.rs
+++ b/src/solve/normalize_application.rs
@@ -17,7 +17,7 @@ impl<'s> NormalizeApplication<'s> {
                q: Query<InEnvironment<Normalize>>)
                -> Self {
         let InEnvironment { environment, goal } = q.value;
-        let infer = InferenceTable::new_with_vars(&q.binders);
+        let infer = InferenceTable::new_from_binders(&q.binders);
         let fulfill = Fulfill::new(solver, infer);
         NormalizeApplication { fulfill, environment, goal }
     }

--- a/src/solve/not_unify.rs
+++ b/src/solve/not_unify.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 
 pub struct SolveNotUnify<'s> {
     solver: &'s mut Solver,
-    binders: Vec<ParameterKind<UniverseIndex>>,
+    binders: QueryBinders,
     environment: Arc<Environment>,
     goal: Not<Unify<Ty>>,
     state: State,

--- a/src/solve/test.rs
+++ b/src/solve/test.rs
@@ -80,7 +80,11 @@ fn prove_clone() {
                         ],
                         constraints: []
                     },
-                    binders: []
+                    binders: QueryBinders {
+                        tys: [],
+                        lifetimes: [],
+                        krates: []
+                    }
                 }
             }"
         }
@@ -97,7 +101,11 @@ fn prove_clone() {
                         ],
                         constraints: []
                     },
-                    binders: []
+                    binders: QueryBinders {
+                        tys: [],
+                        lifetimes: [],
+                        krates: []
+                    }
                 }
             }"
         }
@@ -139,10 +147,11 @@ fn prove_infer() {
                         ],
                         constraints: []
                     },
-                    binders: [
-                        U0,
-                        U0
-                    ]
+                    binders: QueryBinders {
+                        tys: [U0, U0],
+                        lifetimes: [],
+                        krates: []
+                    }
                 }
             }"
         }
@@ -159,7 +168,11 @@ fn prove_infer() {
                         ],
                         constraints: []
                     },
-                    binders: []
+                    binders: QueryBinders {
+                        tys: [],
+                        lifetimes: [],
+                        krates: []
+                    }
                 }
             }"
         }
@@ -176,7 +189,11 @@ fn prove_infer() {
                         ],
                         constraints: []
                     },
-                    binders: []
+                    binders: QueryBinders {
+                        tys: [],
+                        lifetimes: [],
+                        krates: []
+                    }
                 }
             }"
         }
@@ -216,7 +233,11 @@ fn prove_forall() {
                         ],
                         constraints: []
                     },
-                    binders: []
+                    binders: QueryBinders {
+                        tys: [],
+                        lifetimes: [],
+                        krates: []
+                    }
                 }
             }"
         }
@@ -235,7 +256,11 @@ fn prove_forall() {
                         ],
                         constraints: []
                     },
-                    binders: []
+                    binders: QueryBinders {
+                        tys: [],
+                        lifetimes: [],
+                        krates: []
+                    }
                 }
             }"
         }
@@ -265,7 +290,11 @@ fn prove_forall() {
                         ],
                         constraints: []
                     },
-                    binders: []
+                    binders: QueryBinders {
+                        tys: [],
+                        lifetimes: [],
+                        krates: []
+                    }
                 }
             }"
         }
@@ -298,7 +327,11 @@ fn higher_ranked() {
                         ],
                         constraints: []
                     },
-                    binders: []
+                    binders: QueryBinders {
+                        tys: [],
+                        lifetimes: [],
+                        krates: []
+                    }
                 }
             }"
         }
@@ -355,9 +388,11 @@ fn max_depth() {
                         ],
                         constraints: []
                     },
-                    binders: [
-                        U0
-                    ]
+                    binders: QueryBinders {
+                        tys: [U0],
+                        lifetimes: [],
+                        krates: []
+                    }
                 }
             }"
         }
@@ -392,7 +427,11 @@ fn normalize() {
                         ],
                         constraints: []
                     },
-                    binders: []
+                    binders: QueryBinders {
+                        tys: [],
+                        lifetimes: [],
+                        krates: []
+                    }
                 }
             }"
         }
@@ -411,7 +450,11 @@ fn normalize() {
                         ],
                         constraints: []
                     },
-                    binders: []
+                    binders: QueryBinders {
+                        tys: [],
+                        lifetimes: [],
+                        krates: []
+                    }
                 }
             }"
         }
@@ -434,7 +477,11 @@ fn normalize() {
                         ],
                         constraints: []
                     },
-                    binders: []
+                    binders: QueryBinders {
+                        tys: [],
+                        lifetimes: [],
+                        krates: []
+                    }
                 }
             }"
         }
@@ -457,7 +504,11 @@ fn normalize() {
                         ],
                         constraints: []
                     },
-                    binders: []
+                    binders: QueryBinders {
+                        tys: [],
+                        lifetimes: [],
+                        krates: []
+                    }
                 }
             }"
         }
@@ -491,7 +542,11 @@ fn normalize_rev_infer() {
                         ],
                         constraints: []
                     },
-                    binders: []
+                    binders: QueryBinders {
+                        tys: [],
+                        lifetimes: [],
+                        krates: []
+                    }
                 }
             }"
         }
@@ -527,7 +582,11 @@ fn region_equality() {
                             (Env(U2, []) |- LifetimeEq('!2, '!1))
                         ]
                     },
-                    binders: []
+                    binders: QueryBinders {
+                        tys: [],
+                        lifetimes: [],
+                        krates: []
+                    }
                 }
             }"
         }
@@ -548,7 +607,11 @@ fn region_equality() {
                         ],
                         constraints: []
                     },
-                    binders: []
+                    binders: QueryBinders {
+                        tys: [],
+                        lifetimes: [],
+                        krates: []
+                    }
                 }
             }"
         }
@@ -587,7 +650,11 @@ fn forall_equality() {
                         ],
                         constraints: []
                     },
-                    binders: []
+                    binders: QueryBinders {
+                        tys: [],
+                        lifetimes: [],
+                        krates: []
+                    }
                 }
             }"
         }
@@ -612,7 +679,11 @@ fn forall_equality() {
                             (Env(U2, []) |- LifetimeEq('!2, '!1))
                         ]
                     },
-                    binders: []
+                    binders: QueryBinders {
+                        tys: [],
+                        lifetimes: [],
+                        krates: []
+                    }
                 }
             }"
         }
@@ -649,7 +720,11 @@ fn forall_projection() {
                          ],
                          constraints: []
                     },
-                    binders: []
+                    binders: QueryBinders {
+                        tys: [],
+                        lifetimes: [],
+                        krates: []
+                    }
                 }
             }"
         }
@@ -680,7 +755,11 @@ fn elaborate_eq() {
                         ],
                         constraints: []
                     },
-                    binders: []
+                    binders: QueryBinders {
+                        tys: [],
+                        lifetimes: [],
+                        krates: []
+                    }
                 }
             }"
         }
@@ -712,7 +791,11 @@ fn elaborate_transitive() {
                         ],
                         constraints: []
                     },
-                    binders: []
+                    binders: QueryBinders {
+                        tys: [],
+                        lifetimes: [],
+                        krates: []
+                    }
                 }
             }"
         }
@@ -746,7 +829,11 @@ fn elaborate_normalize() {
                         ],
                         constraints: []
                     },
-                    binders: []
+                    binders: QueryBinders {
+                        tys: [],
+                        lifetimes: [],
+                        krates: []
+                    }
                 }
             }"
         }
@@ -797,7 +884,11 @@ fn atc1() {
                         ],
                         constraints: []
                     },
-                    binders: []
+                    binders: QueryBinders {
+                        tys: [],
+                        lifetimes: [],
+                        krates: []
+                    }
                 }
             }"
         }
@@ -869,7 +960,11 @@ fn struct_wf() {
                         ],
                         constraints: []
                     },
-                    binders: []
+                    binders: QueryBinders {
+                        tys: [],
+                        lifetimes: [],
+                        krates: []
+                    }
                 }
             }"
         }
@@ -886,7 +981,11 @@ fn struct_wf() {
                         ],
                         constraints: []
                     },
-                    binders: []
+                    binders: QueryBinders {
+                        tys: [],
+                        lifetimes: [],
+                        krates: []
+                    }
                 }
             }"
         }
@@ -1021,7 +1120,11 @@ fn crate_variable() {
                         ],
                         constraints: []
                     },
-                    binders: []
+                    binders: QueryBinders {
+                        tys: [],
+                        lifetimes: [],
+                        krates: []
+                    }
                 }
             }"
         }
@@ -1163,7 +1266,11 @@ fn normalize_under_binder() {
                         ],
                         constraints: []
                     },
-                    binders: []
+                    binders: QueryBinders {
+                        tys: [],
+                        lifetimes: [],
+                        krates: []
+                    }
                 }
             }"
         }
@@ -1186,9 +1293,11 @@ fn normalize_under_binder() {
                             (Env(U1, []) |- LifetimeEq('?0, '!1))
                         ]
                     },
-                    binders: [
-                        U0
-                    ]
+                    binders: QueryBinders {
+                        tys: [],
+                        lifetimes: [U0],
+                        krates: []
+                    }
                 }
             }"
         }
@@ -1222,9 +1331,11 @@ fn unify_quantified_lifetimes() {
                             (Env(U1, []) |- LifetimeEq('?0, '!1))
                         ]
                     },
-                    binders: [
-                        U0
-                    ]
+                    binders: QueryBinders {
+                        tys: [],
+                        lifetimes: [U0],
+                        krates: []
+                    }
                 }
             }"
         }
@@ -1252,9 +1363,11 @@ fn unify_quantified_lifetimes() {
                             (Env(U1, []) |- LifetimeEq('?0, '!1))
                         ]
                     },
-                    binders: [
-                        U0
-                    ]
+                    binders: QueryBinders {
+                        tys: [],
+                        lifetimes: [U0],
+                        krates: []
+                    }
                 }
             }"
         }
@@ -1289,9 +1402,11 @@ fn equality_binder() {
                             (Env(U2, []) |- LifetimeEq('!2, '?0))
                         ]
                     },
-                    binders: [
-                        U1
-                    ]
+                    binders: QueryBinders {
+                        tys: [],
+                        lifetimes: [U1],
+                        krates: []
+                    }
                 }
             }"
         }

--- a/src/solve/test.rs
+++ b/src/solve/test.rs
@@ -1412,3 +1412,25 @@ fn equality_binder() {
         }
     }
 }
+#[test]
+fn mixed_indices() {
+    test! {
+        program {
+            struct Ref<'a, T> { }
+        }
+        // Check that `'a` (here, `'?0`) is not unified
+        // with `'!1`, because they belong to incompatible
+        // universes.
+        goal {
+            exists<T> {
+                exists<'a> {
+                    exists<U> {
+                        Ref<'a, T> = Ref<'a, U>
+                    }
+                }
+            }
+        } yields {
+            ""
+        }
+    }
+}

--- a/src/solve/unify.rs
+++ b/src/solve/unify.rs
@@ -22,7 +22,7 @@ impl<'s, T> SolveUnify<'s, T>
 {
     pub fn new(solver: &'s mut Solver, env_goal: Query<InEnvironment<Unify<T>>>) -> Self {
         let Query { binders, value: InEnvironment { environment, goal } } = env_goal;
-        let infer = InferenceTable::new_with_vars(&binders);
+        let infer = InferenceTable::new_from_binders(&binders);
         let fulfill = Fulfill::new(solver, infer);
         SolveUnify { fulfill, environment, goal }
     }


### PR DESCRIPTION
Resolves #27 

I have very little confidence that this is actually correct. Best way to learn things. :-)

In order to make sure param indexes match unification table indexes, I separated the binders param on Query into one vec per kind.

This still doesn't compile because I haven't figured out how `InferenceTable::instantiate` works. I figured it would be good to stop now and find out if I'm on the wrong track.