### PR TITLE
Merge `WhereClause` and `WhereClauseGoal` into a single enum

### DIFF
--- a/src/cast.rs
+++ b/src/cast.rs
@@ -24,17 +24,10 @@ macro_rules! reflexive_impl {
 
 reflexive_impl!(TraitRef);
 reflexive_impl!(WhereClause);
-reflexive_impl!(WhereClauseGoal);
 
 impl Cast<WhereClause> for TraitRef {
     fn cast(self) -> WhereClause {
         WhereClause::Implemented(self)
-    }
-}
-
-impl Cast<WhereClauseGoal> for TraitRef {
-    fn cast(self) -> WhereClauseGoal {
-        WhereClauseGoal::Implemented(self)
     }
 }
 
@@ -44,38 +37,23 @@ impl Cast<WhereClause> for Normalize {
     }
 }
 
-impl Cast<WhereClauseGoal> for Normalize {
-    fn cast(self) -> WhereClauseGoal {
-        WhereClauseGoal::Normalize(self)
-    }
-}
-
-impl Cast<WhereClauseGoal> for WellFormed {
-    fn cast(self) -> WhereClauseGoal {
-        WhereClauseGoal::WellFormed(self)
+impl Cast<WhereClause> for WellFormed {
+    fn cast(self) -> WhereClause {
+        WhereClause::WellFormed(self)
     }
 }
 
 impl Cast<Goal> for WellFormed {
     fn cast(self) -> Goal {
-        let wcg: WhereClauseGoal = self.cast();
+        let wcg: WhereClause = self.cast();
         wcg.cast()
     }
 }
 
 impl Cast<Goal> for Normalize {
     fn cast(self) -> Goal {
-        let wcg: WhereClauseGoal = self.cast();
+        let wcg: WhereClause = self.cast();
         wcg.cast()
-    }
-}
-
-impl Cast<WhereClauseGoal> for WhereClause {
-    fn cast(self) -> WhereClauseGoal {
-        match self {
-            WhereClause::Implemented(a) => a.cast(),
-            WhereClause::Normalize(a) => a.cast(),
-        }
     }
 }
 
@@ -87,25 +65,19 @@ impl Cast<Goal> for TraitRef {
 
 impl Cast<Goal> for WhereClause {
     fn cast(self) -> Goal {
-        Goal::Leaf(self.cast())
-    }
-}
-
-impl Cast<Goal> for WhereClauseGoal {
-    fn cast(self) -> Goal {
         Goal::Leaf(self)
     }
 }
 
-impl Cast<WhereClauseGoal> for Unify<Ty> {
-    fn cast(self) -> WhereClauseGoal {
-        WhereClauseGoal::UnifyTys(self)
+impl Cast<WhereClause> for Unify<Ty> {
+    fn cast(self) -> WhereClause {
+        WhereClause::UnifyTys(self)
     }
 }
 
-impl Cast<WhereClauseGoal> for Unify<Lifetime> {
-    fn cast(self) -> WhereClauseGoal {
-        WhereClauseGoal::UnifyLifetimes(self)
+impl Cast<WhereClause> for Unify<Lifetime> {
+    fn cast(self) -> WhereClause {
+        WhereClause::UnifyLifetimes(self)
     }
 }
 

--- a/src/fold/mod.rs
+++ b/src/fold/mod.rs
@@ -178,9 +178,8 @@ macro_rules! enum_fold {
 }
 
 enum_fold!(ParameterKind[T,L] { Ty(a), Lifetime(a) } where T: Fold, L: Fold);
-enum_fold!(WhereClause[] { Implemented(a), Normalize(a) });
 enum_fold!(WellFormed[] { Ty(a), TraitRef(a) });
-enum_fold!(WhereClauseGoal[] { Implemented(a), Normalize(a), UnifyTys(a),
+enum_fold!(WhereClause[] { Implemented(a), Normalize(a), UnifyTys(a),
                                UnifyLifetimes(a), WellFormed(a) });
 enum_fold!(Constraint[] { LifetimeEq(a, b) });
 enum_fold!(Goal[] { Quantified(qkind, subgoal), Implies(wc, subgoal), And(g1, g2), Leaf(wc) });

--- a/src/ir/debug.rs
+++ b/src/ir/debug.rs
@@ -156,24 +156,9 @@ impl Debug for WhereClause {
                        n.trait_id,
                        Angle(&n.parameters[1..]))
             }
-        }
-    }
-}
-
-impl Debug for WhereClauseGoal {
-    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
-        match *self {
-            WhereClauseGoal::Normalize(ref n) => write!(fmt, "{:?}", n),
-            WhereClauseGoal::Implemented(ref n) => {
-                write!(fmt,
-                       "{:?}: {:?}{:?}",
-                       n.parameters[0],
-                       n.trait_id,
-                       Angle(&n.parameters[1..]))
-            }
-            WhereClauseGoal::UnifyTys(ref n) => write!(fmt, "{:?}", n),
-            WhereClauseGoal::UnifyLifetimes(ref n) => write!(fmt, "{:?}", n),
-            WhereClauseGoal::WellFormed(ref n) => write!(fmt, "{:?}", n),
+            WhereClause::UnifyTys(ref n) => write!(fmt, "{:?}", n),
+            WhereClause::UnifyLifetimes(ref n) => write!(fmt, "{:?}", n),
+            WhereClause::WellFormed(ref n) => write!(fmt, "{:?}", n),
         }
     }
 }

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -130,6 +130,7 @@ impl Environment {
                     };
                     push_clause(trait_ref.cast());
                 }
+                _ => (),
             }
         }
 
@@ -370,12 +371,6 @@ pub struct TraitRef {
 pub enum WhereClause {
     Implemented(TraitRef),
     Normalize(Normalize),
-}
-
-#[derive(Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub enum WhereClauseGoal {
-    Implemented(TraitRef),
-    Normalize(Normalize),
     UnifyTys(Unify<Ty>),
     UnifyLifetimes(Unify<Lifetime>),
     WellFormed(WellFormed),
@@ -436,7 +431,7 @@ pub struct ProgramClause {
 /// Represents one clause of the form `consequence :- conditions`.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct ProgramClauseImplication {
-    pub consequence: WhereClauseGoal,
+    pub consequence: WhereClause,
     pub conditions: Vec<Goal>,
 }
 
@@ -480,7 +475,7 @@ pub enum Goal {
     Quantified(QuantifierKind, Binders<Box<Goal>>),
     Implies(Vec<WhereClause>, Box<Goal>),
     And(Box<Goal>, Box<Goal>),
-    Leaf(WhereClauseGoal),
+    Leaf(WhereClause),
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]

--- a/src/solve/fulfill.rs
+++ b/src/solve/fulfill.rs
@@ -12,7 +12,7 @@ use zip::Zip;
 pub struct Fulfill<'s> {
     solver: &'s mut Solver,
     infer: InferenceTable,
-    obligations: Vec<InEnvironment<WhereClauseGoal>>,
+    obligations: Vec<InEnvironment<WhereClause>>,
     constraints: HashSet<InEnvironment<Constraint>>,
 }
 
@@ -79,13 +79,13 @@ impl<'s> Fulfill<'s> {
     /// Adds the given where-clauses to the internal list of
     /// obligations that must be solved.
     pub fn extend<WC>(&mut self, wc: WC)
-        where WC: IntoIterator<Item=InEnvironment<WhereClauseGoal>>
+        where WC: IntoIterator<Item=InEnvironment<WhereClause>>
     {
         self.obligations.extend(wc);
     }
 
     /// Return current list of pending obligations; used for unit testing primarily
-    pub fn pending_obligations(&self) -> &[InEnvironment<WhereClauseGoal>] {
+    pub fn pending_obligations(&self) -> &[InEnvironment<WhereClause>] {
         &self.obligations
     }
 
@@ -210,7 +210,7 @@ impl<'s> Fulfill<'s> {
     }
 
     fn solve_one(&mut self,
-                 wc: &InEnvironment<WhereClauseGoal>,
+                 wc: &InEnvironment<WhereClause>,
                  inference_progress: &mut bool)
                  -> Result<Successful> {
         debug!("fulfill::solve_one(wc={:?})", wc);

--- a/src/solve/infer/unify.rs
+++ b/src/solve/infer/unify.rs
@@ -32,13 +32,13 @@ struct Unifier<'t> {
     table: &'t mut InferenceTable,
     environment: &'t Arc<Environment>,
     snapshot: InferenceSnapshot,
-    goals: Vec<InEnvironment<WhereClauseGoal>>,
+    goals: Vec<InEnvironment<WhereClause>>,
     constraints: Vec<InEnvironment<Constraint>>,
 }
 
 #[derive(Debug)]
 pub struct UnificationResult {
-    pub goals: Vec<InEnvironment<WhereClauseGoal>>,
+    pub goals: Vec<InEnvironment<WhereClause>>,
     pub constraints: Vec<InEnvironment<Constraint>>,
 }
 

--- a/src/solve/match_any.rs
+++ b/src/solve/match_any.rs
@@ -20,7 +20,7 @@ enum Technique<'t> {
 }
 
 impl<'s, G> MatchAny<'s, G>
-    where G: Cast<WhereClause> + Cast<WhereClauseGoal> + Clone + Hash + Eq + Fold<Result = G>
+    where G: Cast<WhereClause> + Clone + Hash + Eq + Fold<Result = G>
 {
     pub fn new(solver: &'s mut Solver, env_goal: &'s Query<InEnvironment<G>>) -> Self {
         MatchAny {

--- a/src/solve/match_program_clause.rs
+++ b/src/solve/match_program_clause.rs
@@ -15,7 +15,7 @@ pub struct MatchProgramClause<'s, G: 's> {
 }
 
 impl<'s, G> MatchProgramClause<'s, G>
-    where G: Clone + Cast<WhereClauseGoal> + Fold<Result = G>
+    where G: Clone + Cast<WhereClause> + Fold<Result = G>
 {
     pub fn new(solver: &'s mut Solver,
                q: &'s Query<InEnvironment<G>>,

--- a/src/solve/mod.rs
+++ b/src/solve/mod.rs
@@ -8,6 +8,7 @@ pub mod match_clause;
 pub mod match_program_clause;
 pub mod normalize;
 pub mod normalize_application;
+pub mod well_formed;
 pub mod prove;
 pub mod solver;
 pub mod unify;

--- a/src/solve/prove.rs
+++ b/src/solve/prove.rs
@@ -6,7 +6,7 @@ use solve::Solution;
 
 pub struct Prove<'s> {
     fulfill: Fulfill<'s>,
-    goals: Vec<InEnvironment<WhereClauseGoal>>,
+    goals: Vec<InEnvironment<WhereClause>>,
 }
 
 impl<'s> Prove<'s> {
@@ -21,7 +21,7 @@ impl<'s> Prove<'s> {
         prove
     }
 
-    pub fn solve(mut self) -> Result<Solution<Vec<WhereClauseGoal>>> {
+    pub fn solve(mut self) -> Result<Solution<Vec<WhereClause>>> {
         let successful = self.fulfill.solve_all()?;
         let goals: Vec<_> = self.goals.into_iter().map(|g| g.goal).collect();
         let refined_goal = self.fulfill.refine_goal(goals);

--- a/src/solve/test.rs
+++ b/src/solve/test.rs
@@ -1226,3 +1226,22 @@ fn mixed_indices_normalize_application() {
         }
     }
 }
+
+#[test]
+fn extended_where_clauses() {
+    test! {
+        program {
+            trait Foo { }
+        }
+
+        goal {
+            forall<T> {
+                if (WellFormed(T: Foo)) {
+                    WellFormed(T: Foo)
+                }
+            }
+        } yields {
+            "Solution { successful: Yes"
+        }
+    }
+}

--- a/src/solve/well_formed.rs
+++ b/src/solve/well_formed.rs
@@ -1,0 +1,24 @@
+use errors::*;
+use ir::*;
+use solve::match_any::MatchAny;
+use solve::solver::Solver;
+use solve::Solution;
+
+pub struct SolveWellFormed<'s> {
+    solver: &'s mut Solver,
+    env_goal: Query<InEnvironment<WellFormed>>,
+}
+
+impl<'s> SolveWellFormed<'s> {
+    pub fn new(solver: &'s mut Solver, env_goal: Query<InEnvironment<WellFormed>>) -> Self {
+        SolveWellFormed {
+            solver: solver,
+            env_goal: env_goal,
+        }
+    }
+
+    pub fn solve(self) -> Result<Solution<InEnvironment<WellFormed>>> {
+        let SolveWellFormed { solver, env_goal } = self;
+        MatchAny::new(solver, &env_goal).solve()
+    }
+}

--- a/src/zip.rs
+++ b/src/zip.rs
@@ -155,6 +155,5 @@ macro_rules! enum_zip {
     }
 }
 
-enum_zip!(WhereClause { Implemented, Normalize });
-enum_zip!(WhereClauseGoal { Implemented, Normalize, UnifyTys, UnifyLifetimes, WellFormed });
+enum_zip!(WhereClause { Implemented, Normalize, UnifyTys, UnifyLifetimes, WellFormed });
 enum_zip!(WellFormed { Ty, TraitRef });


### PR DESCRIPTION
The two enums were merged into a single one named `WhereClause`. In particular, chalk syntax is now a superset of rust syntax and `WellFormed` types are now allowed into the environment. This is a preparation for solving #12.