### PR TITLE
Clarify ambiguity during unification; overhaul normalization fallback

### DIFF
--- a/src/bin/repl.rs
+++ b/src/bin/repl.rs
@@ -86,7 +86,7 @@ fn process(command: &str, rl: &mut rustyline::Editor<()>, prog: &mut Option<Prog
         ir::set_current_program(&prog.ir, || -> Result<()> {
             match command {
                 "print" => println!("{}", prog.text),
-                "lowered" => println!("{:?}", prog.ir),
+                "lowered" => println!("{:#?}", prog.env),
                 _ => goal(command, prog)?,
             }
             Ok(())
@@ -120,11 +120,8 @@ fn goal(text: &str, prog: &Program) -> Result<()> {
     let goal = chalk_parse::parse_goal(text)?.lower(&*prog.ir)?;
     let overflow_depth = 10;
     let mut solver = Solver::new(&prog.env, overflow_depth);
-    let goal = ir::Canonical {
-        value: ir::InEnvironment::new(&ir::Environment::new(), *goal),
-        binders: vec![],
-    };
-    match solver.solve_goal(goal) {
+    let goal = ir::InEnvironment::new(&ir::Environment::new(), *goal);
+    match solver.solve_closed_goal(goal) {
         Ok(v) => println!("{}\n", v),
         Err(e) => println!("No possible solution: {}\n", e),
     }

--- a/src/fold/mod.rs
+++ b/src/fold/mod.rs
@@ -196,7 +196,7 @@ macro_rules! enum_fold {
 }
 
 enum_fold!(ParameterKind[T,L] { Ty(a), Lifetime(a) } where T: Fold, L: Fold);
-enum_fold!(DomainGoal[] { Implemented(a), RawNormalize(a), Normalize(a), WellFormed(a) });
+enum_fold!(DomainGoal[] { Implemented(a), Normalize(a), WellFormed(a) });
 enum_fold!(WellFormed[] { Ty(a), TraitRef(a) });
 enum_fold!(LeafGoal[] { EqGoal(a), DomainGoal(a) });
 enum_fold!(Constraint[] { LifetimeEq(a, b) });

--- a/src/ir/debug.rs
+++ b/src/ir/debug.rs
@@ -149,7 +149,6 @@ impl Debug for DomainGoal {
     fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
         match *self {
             DomainGoal::Normalize(ref n) => write!(fmt, "{:?}", n),
-            DomainGoal::RawNormalize(ref n) => write!(fmt, "raw {{ {:?} }}", n),
             DomainGoal::Implemented(ref n) => {
                 write!(fmt,
                        "{:?}: {:?}{:?}",

--- a/src/solve/infer/mod.rs
+++ b/src/solve/infer/mod.rs
@@ -159,7 +159,7 @@ impl Lifetime {
 impl Substitution {
     /// Check whether this substitution is the identity substitution in the
     /// given inference context.
-    pub fn is_trivial(&self, in_infer: &mut InferenceTable) -> bool {
+    pub fn is_trivial_within(&self, in_infer: &mut InferenceTable) -> bool {
         for ty in self.tys.values() {
             if let Some(var) = ty.inference_var() {
                 if in_infer.probe_var(var).is_some() {

--- a/src/solve/infer/unify.rs
+++ b/src/solve/infer/unify.rs
@@ -116,6 +116,7 @@ impl<'t> Unifier<'t> {
                 if apply1.name != apply2.name {
                     if apply1.name.is_for_all() || apply2.name.is_for_all() {
                         self.ambiguous = true;
+                        return Ok(());
                     } else {
                         bail!("cannot equate `{:?}` and `{:?}`", apply1.name, apply2.name);
                     }

--- a/src/zip.rs
+++ b/src/zip.rs
@@ -155,6 +155,6 @@ macro_rules! enum_zip {
     }
 }
 
-enum_zip!(DomainGoal { Implemented, RawNormalize, Normalize, WellFormed });
+enum_zip!(DomainGoal { Implemented, Normalize, WellFormed });
 enum_zip!(LeafGoal { DomainGoal, EqGoal });
 enum_zip!(WellFormed { Ty, TraitRef });


### PR DESCRIPTION
This PR makes a few important changes:

- It clarifies ambiguity during unification so that we understand a query like `!0 = i32` or `!0 = !1` as asking the question *for all possible substitutions*, meaning that we can neither prove nor refute it, and hence return an ambiguous result.

- Furthermore, we treat *program clauses* as comprising a closed world (as intended) that cannot be extended further through environmental assumptions. That means, in particular, that we can simply ignore environmental assumptions that would require ambiguous unification to employ.

- Rather than using negation for normalization fallback, we introduce an explicit notion of "fallback program clauses" which are employed only when it is clear that no other forward progress on the goal is possible.