### PR TITLE
First version of overlap check.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,6 +79,7 @@ dependencies = [
  "chalk-parse 0.1.0",
  "ena 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lalrpop-intern 0.12.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustyline 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -108,6 +109,11 @@ dependencies = [
  "rustc-serialize 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "strsim 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "either"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "ena"
@@ -141,6 +147,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "itertools"
 version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "itertools"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "either 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "kernel32-sys"
@@ -352,12 +366,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum dbghelp-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "97590ba53bcb8ac28279161ca943a924d1fd4a8fb3fa63302591647c4fc5b850"
 "checksum diff 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e48977eec6d3b7707462c2dc2e1363ad91b5dd822cf942537ccdc2085dc87587"
 "checksum docopt 0.6.86 (registry+https://github.com/rust-lang/crates.io-index)" = "4a7ef30445607f6fc8720f0a0a2c7442284b629cf0d049286860fae23e71c4d9"
+"checksum either 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "18785c1ba806c258137c937e44ada9ee7e69a37e3c72077542cd2f069d78562a"
 "checksum ena 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5c109645f12ca057044ef2ffa56670cf7e3fd1fa530d73cd185e8298b03380b5"
 "checksum encode_unicode 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "28d65f1f5841ef7c6792861294b72beda34c664deb8be27970f36c306b7da1ce"
 "checksum error-chain 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "318cb3c71ee4cdea69fdc9e15c173b245ed6063e1709029e8fd32525a881120f"
 "checksum fixedbitset 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "88c3c33fc4c00db33f5174eb98aea809c4c007db0b71351d810a7e094ea3b64d"
 "checksum gcc 0.3.41 (registry+https://github.com/rust-lang/crates.io-index)" = "3689e1982a563af74960ae3a4758aa632bb8fd984cfc3cc3b60ee6109477ab6e"
 "checksum itertools 0.3.25 (registry+https://github.com/rust-lang/crates.io-index)" = "16b73f1c685cfd8ff8d75698ed87e6188cd09944b30c0863d45c2c3699d1da0c"
+"checksum itertools 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "772a0928a97246167d59a2a4729df5871f1327ab8b36fd24c4224b229cb47b99"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lalrpop 0.12.4 (registry+https://github.com/rust-lang/crates.io-index)" = "95af72b26d2056ca73387cb71d29e727c336d2b8a766ee09b210bed44d6f857b"
 "checksum lalrpop-intern 0.12.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4e76b1f6eead09c4edde090dc69e3757775ab36cbf907fb0857181160b9ca5a1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,14 +1,17 @@
 [package]
+authors = ["Niko Matsakis <niko@alum.mit.edu>"]
 name = "chalk"
 version = "0.1.0"
-authors = ["Niko Matsakis <niko@alum.mit.edu>"]
-
-[workspace]
 
 [dependencies]
-chalk-parse = { path = "chalk-parse" }
 ena = "0.4"
 error-chain = "0.7.2"
+itertools = "0.6.0"
 lalrpop-intern = "0.12.1"
 lazy_static = "0.2.2"
 rustyline = "1.0"
+
+[dependencies.chalk-parse]
+path = "chalk-parse"
+
+[workspace]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,4 +1,5 @@
 use chalk_parse::{self, ast};
+use ir;
 
 error_chain! {
     links {
@@ -26,6 +27,11 @@ error_chain! {
         NotTrait(identifier: ast::Identifier) {
             description("not a trait")
             display("expected a trait, found `{}`, which is not a trait", identifier.str)
+        }
+
+        OverlappingImpls(trait_id: ir::Identifier) {
+            description("overlapping impls")
+            display("overlapping impls of trait {:?}", trait_id)
         }
     }
 }

--- a/src/fold/shifter.rs
+++ b/src/fold/shifter.rs
@@ -35,6 +35,7 @@ up_shift_method!(Parameter);
 up_shift_method!(Lifetime);
 up_shift_method!(TraitRef);
 up_shift_method!(ProjectionTy);
+up_shift_method!(DomainGoal);
 
 impl Folder for Shifter {
     fn fold_free_var(&mut self, depth: usize, binders: usize) -> Result<Ty> {

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -160,6 +160,10 @@ impl<G> InEnvironment<G> {
         InEnvironment { environment: environment.clone(), goal }
     }
 
+    pub fn empty(goal: G) -> Self {
+        InEnvironment { environment: Environment::new(), goal }
+    }
+
     pub fn map<OP, H>(self, op: OP) -> InEnvironment<H>
         where OP: FnOnce(G) -> H
     {
@@ -541,6 +545,12 @@ pub enum Goal {
     And(Box<Goal>, Box<Goal>),
     Not(Box<Goal>),
     Leaf(LeafGoal),
+}
+
+impl Goal {
+    pub fn quantify(self, kind: QuantifierKind, binders: Vec<ParameterKind<()>>) -> Goal {
+        Goal::Quantified(kind, Binders { value: Box::new(self), binders })
+    }
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ extern crate chalk_parse;
 #[macro_use]
 extern crate error_chain;
 extern crate ena;
+extern crate itertools;
 extern crate lalrpop_intern;
 #[macro_use]
 extern crate lazy_static;
@@ -19,5 +20,6 @@ pub mod errors;
 pub mod fold;
 pub mod ir;
 pub mod lower;
+pub mod overlap;
 pub mod solve;
 pub mod zip;

--- a/src/lower/mod.rs
+++ b/src/lower/mod.rs
@@ -1,9 +1,11 @@
-use cast::Cast;
+use std::collections::HashMap;
+
 use chalk_parse::ast::*;
 use lalrpop_intern::intern;
+
+use cast::Cast;
 use errors::*;
 use ir;
-use std::collections::HashMap;
 
 mod test;
 
@@ -183,7 +185,9 @@ impl LowerProgram for Program {
             }
         }
 
-        Ok(ir::Program { type_ids, type_kinds, struct_data, trait_data, impl_data, associated_ty_data, })
+        let program = ir::Program { type_ids, type_kinds, struct_data, trait_data, impl_data, associated_ty_data, };
+        program.check_overlapping_impls()?;
+        Ok(program)
     }
 }
 

--- a/src/lower/test.rs
+++ b/src/lower/test.rs
@@ -292,6 +292,7 @@ fn two_blanket_impls() {
 }
 
 #[test]
+#[ignore] // Ignored until we have the compat modality
 fn two_blanket_impls_open_ended() {
     lowering_error! {
         program {

--- a/src/lower/test.rs
+++ b/src/lower/test.rs
@@ -281,6 +281,25 @@ fn two_blanket_impls() {
             trait Baz { }
             impl<T> Foo for T where T: Bar { }
             impl<T> Foo for T where T: Baz { }
+            struct Quux { }
+            impl Bar for Quux { }
+            impl Baz for Quux { }
+        }
+        error_msg {
+            "overlapping impls of trait \"Foo\""
+        }
+    }
+}
+
+#[test]
+fn two_blanket_impls_open_ended() {
+    lowering_error! {
+        program {
+            trait Foo { }
+            trait Bar { }
+            trait Baz { }
+            impl<T> Foo for T where T: Bar { }
+            impl<T> Foo for T where T: Baz { }
         }
         error_msg {
             "overlapping impls of trait \"Foo\""

--- a/src/lower/test.rs
+++ b/src/lower/test.rs
@@ -292,18 +292,20 @@ fn two_blanket_impls() {
 }
 
 #[test]
-#[ignore] // Ignored until we have the compat modality
+// FIXME This should be an error
+// We currently assume a closed universe always, but overlaps checking should
+// assume an open universe - what if a client implemented both Bar and Baz
+//
+// In other words, this should have the same behavior as the two_blanket_impls
+// test.
 fn two_blanket_impls_open_ended() {
-    lowering_error! {
+    lowering_success! {
         program {
             trait Foo { }
             trait Bar { }
             trait Baz { }
             impl<T> Foo for T where T: Bar { }
             impl<T> Foo for T where T: Baz { }
-        }
-        error_msg {
-            "overlapping impls of trait \"Foo\""
         }
     }
 }

--- a/src/overlap.rs
+++ b/src/overlap.rs
@@ -1,0 +1,75 @@
+use std::sync::Arc;
+
+use itertools::Itertools;
+
+use errors::*;
+use ir::*;
+use solve::solver::Solver;
+
+impl Program {
+    pub fn check_overlapping_impls(&self) -> Result<()> {
+        let mut solver = Solver::new(&Arc::new(self.environment()), 10);
+
+        // Group impls by trait.
+        let impl_groupings = self.impl_data.iter().group_by(|&(_, impl_datum)| {
+            impl_datum.binders.value.trait_ref.trait_id
+        });
+
+        for (trait_id, impls) in &impl_groupings {
+            // Get all the pairs of impls from this trait
+            let impls: Vec<&ImplDatum> = impls.map(|(_, impl_datum)| impl_datum).collect();
+
+            // For each pair, check their overlap by generating an "intersection"
+            // goal. In this case, success is an error - it means that there is at
+            // least one type in the intersection of these two impls.
+            for (lhs, rhs) in impls.into_iter().tuple_combinations() {
+                match solver.solve_goal(intersection_of(lhs, rhs)) {
+                    Ok(_)   => {
+                        let trait_id = self.type_kinds.get(&trait_id).unwrap().name;
+                        Err(Error::from_kind(ErrorKind::OverlappingImpls(trait_id)))
+                    }
+                    Err(_)  => Ok(())
+                }?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+// The goal to test overlap.
+//
+// If this goal succeeds, these two impls overlap.
+fn intersection_of(lhs: &ImplDatum, rhs: &ImplDatum) -> Canonical<InEnvironment<Goal>> {
+    fn params(impl_datum: &ImplDatum) -> &[Parameter] {
+        &impl_datum.binders.value.trait_ref.parameters
+    }
+
+    debug_assert!(params(lhs).len() == params(rhs).len());
+
+    // Join the two impls' binders together 
+    let mut binders = lhs.binders.binders.clone();
+    binders.extend(rhs.binders.binders.clone());
+
+    // Upshift the rhs variables to account for the joined binders
+    let lhs_params = params(lhs).iter().cloned();
+    let rhs_params = params(rhs).iter().map(|param| param.up_shift(lhs.binders.len()));
+
+    // Create an equality goal of inputs to the trait, attempting to unify
+    // the inputs to both impls with each other
+    let goal = lhs_params.zip(rhs_params)
+                .map(|(a, b)| Goal::Leaf(LeafGoal::EqGoal(EqGoal { a, b })))
+                .fold1(|goal, leaf| Goal::And(Box::new(goal), Box::new(leaf)))
+                .expect("Every trait takes at least one input type");
+
+    Canonical {
+        value: InEnvironment {
+            environment: Environment::new(),
+            goal: Goal::Quantified(QuantifierKind::Exists, Binders {
+                value: Box::new(goal),
+                binders: binders,
+            }),
+        },
+        binders: vec![],
+    }
+}

--- a/src/overlap.rs
+++ b/src/overlap.rs
@@ -55,6 +55,9 @@ fn intersection_of(lhs: &ImplDatum, rhs: &ImplDatum) -> Canonical<InEnvironment<
     let lhs_params = params(lhs).iter().cloned();
     let rhs_params = params(rhs).iter().map(|param| param.up_shift(lhs.binders.len()));
 
+    let mut where_clauses = lhs.binders.value.where_clauses.clone();
+    where_clauses.extend(rhs.binders.value.where_clauses.clone());
+
     // Create an equality goal of inputs to the trait, attempting to unify
     // the inputs to both impls with each other
     let goal = lhs_params.zip(rhs_params)
@@ -66,7 +69,7 @@ fn intersection_of(lhs: &ImplDatum, rhs: &ImplDatum) -> Canonical<InEnvironment<
         value: InEnvironment {
             environment: Environment::new(),
             goal: Goal::Quantified(QuantifierKind::Exists, Binders {
-                value: Box::new(goal),
+                value: Box::new(Goal::Implies(where_clauses, Box::new(goal))),
                 binders: binders,
             }),
         },


### PR DESCRIPTION
This check works by pairing every 2 impls of the same trait and then
generating a goal to prove that a type lies in the intersection of
those two impls. If the goal succeeds, we have found the overlap.

The goal that is lowered looks like this:

```rust
impl Foo for i32 { }
impl Foo for u32 { }

exists<> { i32 = u32 }
```

```rust
impl<T> Foo for T { }
impl Foo for i32 { }
exists<T> { T = i32 }
```

```rust
impl<T> Foo for Vec<T>
impl<T> Foo for Vec<i32>
exists<T> { Vec<T> = Vec<i32>
```

And so on.

Currently, this goal does not take into consideration where clauses
on the impl. For that reason, the local negative reasoning, as in the
example below, is not implemented:

```rust
trait Bar { }
trait Foo { }
struct MyType;
impl<T: Bar> Foo for T { }
impl T for MyType { }
```

A test exists to check this, which is failing.