### PR TITLE
Add `CannotProve` solution

### DIFF
--- a/src/solve/fulfill.rs
+++ b/src/solve/fulfill.rs
@@ -326,6 +326,7 @@ impl<'s> Fulfill<'s> {
             }
 
             self.obligations.extend(obligations.drain(..));
+            debug!("end of round, {} obligations left", self.obligations.len());
         }
 
         // At the end of this process, `self.obligations` should have

--- a/src/solve/fulfill.rs
+++ b/src/solve/fulfill.rs
@@ -23,10 +23,6 @@ impl Outcome {
     }
 }
 
-pub struct UnifyOutcome {
-    pub ambiguous: bool,
-}
-
 /// A goal that must be resolved
 #[derive(Clone, Debug, PartialEq, Eq)]
 enum Obligation {
@@ -53,6 +49,7 @@ struct PositiveSolution {
 enum NegativeSolution {
     Refuted,
     Ambiguous,
+    CannotProve,
 }
 
 /// A `Fulfill` is where we actually break down complex goals, instantiate
@@ -75,10 +72,7 @@ pub struct Fulfill<'s> {
     /// Lifetime constraints that must be fulfilled for a solution to be fully
     /// validated.
     constraints: HashSet<InEnvironment<Constraint>>,
-
-    /// Record that a goal has been processed that can neither be proved nor
-    /// refuted, and thus the overall solution cannot be `Unique`
-    ambiguous: bool,
+    cannot_prove: bool,
 }
 
 impl<'s> Fulfill<'s> {
@@ -88,7 +82,7 @@ impl<'s> Fulfill<'s> {
             infer: InferenceTable::new(),
             obligations: vec![],
             constraints: HashSet::new(),
-            ambiguous: false,
+            cannot_prove: false,
         }
     }
 
@@ -119,19 +113,19 @@ impl<'s> Fulfill<'s> {
     ///
     /// Wraps `InferenceTable::unify`; any resulting normalizations are added
     /// into our list of pending obligations with the given environment.
-    pub fn unify<T>(&mut self, environment: &Arc<Environment>, a: &T, b: &T) -> Result<UnifyOutcome>
+    pub fn unify<T>(&mut self, environment: &Arc<Environment>, a: &T, b: &T) -> Result<()>
         where T: ?Sized + Zip + Debug
     {
-        let UnificationResult { goals, constraints, ambiguous } =
+        let UnificationResult { goals, constraints, cannot_prove } =
             self.infer.unify(environment, a, b)?;
         debug!("unify({:?}, {:?}) succeeded", a, b);
         debug!("unify: goals={:?}", goals);
         debug!("unify: constraints={:?}", constraints);
-        debug!("unify: ambiguous={:?}", ambiguous);
+        debug!("unify: cannot_prove={:?}", cannot_prove);
         self.constraints.extend(constraints);
         self.obligations.extend(goals.into_iter().map(Obligation::Prove));
-        self.ambiguous = self.ambiguous || ambiguous;
-        Ok(UnifyOutcome { ambiguous })
+        self.cannot_prove = self.cannot_prove || cannot_prove;
+        Ok(())
     }
 
     /// Create obligations for the given goal in the given environment. This may
@@ -223,10 +217,11 @@ impl<'s> Fulfill<'s> {
         }
 
         // Negate the result
-        if let Ok(solution) =  self.solver.solve_closed_goal(canonicalized.quantified.value) {
+        if let Ok(solution) = self.solver.solve_closed_goal(canonicalized.quantified.value) {
             match solution {
                 Solution::Unique(_) => Err("refutation failed")?,
                 Solution::Ambig(_) => Ok(NegativeSolution::Ambiguous),
+                Solution::CannotProve => Ok(NegativeSolution::CannotProve),
             }
         } else {
             Ok(NegativeSolution::Refuted)
@@ -301,7 +296,7 @@ impl<'s> Fulfill<'s> {
             // directly.
             assert!(obligations.is_empty());
             while let Some(obligation) = self.obligations.pop() {
-                let ambiguous = match obligation {
+                let (ambiguous, cannot_prove) = match obligation {
                     Obligation::Prove(ref wc) => {
                         let PositiveSolution { free_vars, solution } = self.prove(wc)?;
 
@@ -312,10 +307,11 @@ impl<'s> Fulfill<'s> {
                             }
                         }
 
-                        solution.is_ambig()
+                        (solution.is_ambig(), solution.cannot_be_proven())
                     }
                     Obligation::Refute(ref goal) => {
-                        self.refute(goal)? == NegativeSolution::Ambiguous
+                        let answer = self.refute(goal)?;
+                        (answer == NegativeSolution::Ambiguous, answer == NegativeSolution::CannotProve)
                     }
                 };
 
@@ -323,13 +319,16 @@ impl<'s> Fulfill<'s> {
                     debug!("ambiguous result: {:?}", obligation);
                     obligations.push(obligation);
                 }
+
+                // If one of the obligations cannot be proven, then the whole goal
+                // cannot be proven either.
+                self.cannot_prove = self.cannot_prove || cannot_prove;
             }
 
             self.obligations.extend(obligations.drain(..));
-            debug!("end of round, {} obligations left", self.obligations.len());
         }
 
-        // At the end of this process, `self.to_prove` should have
+        // At the end of this process, `self.obligations` should have
         // all of the ambiguous obligations, and `obligations` should
         // be empty.
         assert!(obligations.is_empty());
@@ -346,7 +345,12 @@ impl<'s> Fulfill<'s> {
     /// the outcome of type inference by updating the replacements it provides.
     pub fn solve(mut self, subst: Substitution) -> Result<Solution> {
         let outcome = self.fulfill()?;
-        if outcome.is_complete() && !self.ambiguous {
+
+        if self.cannot_prove {
+            return Ok(Solution::CannotProve);
+        }
+
+        if outcome.is_complete() {
             // No obligations remain, so we have definitively solved our goals,
             // and the current inference state is the unique way to solve them.
 

--- a/src/solve/fulfill.rs
+++ b/src/solve/fulfill.rs
@@ -72,6 +72,10 @@ pub struct Fulfill<'s> {
     /// Lifetime constraints that must be fulfilled for a solution to be fully
     /// validated.
     constraints: HashSet<InEnvironment<Constraint>>,
+
+    /// Record that a goal has been processed that can neither be proved nor
+    /// refuted. In such a case the solution will be either `CannotProve`, or `Err`
+    /// in the case where some other goal leads to an error.
     cannot_prove: bool,
 }
 
@@ -320,8 +324,9 @@ impl<'s> Fulfill<'s> {
                     obligations.push(obligation);
                 }
 
-                // If one of the obligations cannot be proven, then the whole goal
-                // cannot be proven either.
+                // If one of the obligations cannot be proven then the whole goal
+                // cannot be proven either, unless another obligation leads to an error
+                // in which case the function will bail out normally.
                 self.cannot_prove = self.cannot_prove || cannot_prove;
             }
 

--- a/src/solve/test.rs
+++ b/src/solve/test.rs
@@ -142,7 +142,13 @@ fn prove_forall() {
         goal {
             forall<T> { T: Marker }
         } yields {
-            "Ambiguous; no inference guidance"
+            "CannotProve"
+        }
+
+        goal {
+            forall<T> { not { T: Marker } }
+        } yields {
+            "CannotProve"
         }
 
         // If we assume `T: Marker`, then obviously `T: Marker`.
@@ -165,7 +171,7 @@ fn prove_forall() {
         goal {
             forall<T> { Vec<T>: Clone }
         } yields {
-            "Ambig"
+            "CannotProve"
         }
 
         // Here, we do know that `T: Clone`, so we can.
@@ -288,7 +294,7 @@ fn normalize_basic() {
                 }
             }
         } yields {
-            "Ambiguous; suggested substitution [?0 := u32]"
+            "Unique; substitution [?0 := u32]"
         }
 
         goal {
@@ -1168,7 +1174,7 @@ fn negation_quantifiers() {
                 }
             }
         } yields {
-            "Ambig"
+            "CannotProve"
         }
 
         goal {
@@ -1188,7 +1194,7 @@ fn negation_quantifiers() {
                 }
             }
         } yields {
-            "Ambig"
+            "CannotProve"
         }
     }
 }


### PR DESCRIPTION
Added a `CannotProve` solution in order to deal with #44. In particular, unifying a *for all* variable with something else automatically leads to `CannotProve` (or error). `CannotProve` solutions have the lowest priority when combining multiple solutions.

Examples 1 and 2 in this issue are now all treated as `CannotProve`. Example 3 is not shown in this PR since this specific issue arises only when elaborating clauses à la #12, but this PR will indeed resolve this ambiguity in the future.