### PR TITLE
Implement a tabling strategy for handling cycles

### DIFF
--- a/src/bin/chalki.rs
+++ b/src/bin/chalki.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 
 use chalk::ir;
 use chalk::lower::*;
-use chalk::solve::solver::Solver;
+use chalk::solve::solver::{Solver, CycleStrategy};
 
 use rustyline::error::ReadlineError;
 
@@ -118,8 +118,7 @@ fn read_program(rl: &mut rustyline::Editor<()>) -> Result<String> {
 
 fn goal(text: &str, prog: &Program) -> Result<()> {
     let goal = chalk_parse::parse_goal(text)?.lower(&*prog.ir)?;
-    let overflow_depth = 10;
-    let mut solver = Solver::new(&prog.env, overflow_depth);
+    let mut solver = Solver::new(&prog.env, CycleStrategy::Tabling);
     let goal = ir::InEnvironment::new(&ir::Environment::new(), *goal);
     match solver.solve_closed_goal(goal) {
         Ok(v) => println!("{}\n", v),

--- a/src/overlap.rs
+++ b/src/overlap.rs
@@ -4,11 +4,11 @@ use itertools::Itertools;
 
 use errors::*;
 use ir::*;
-use solve::solver::Solver;
+use solve::solver::{Solver, CycleStrategy};
 
 impl Program {
     pub fn check_overlapping_impls(&self) -> Result<()> {
-        let mut solver = Solver::new(&Arc::new(self.environment()), 10);
+        let mut solver = Solver::new(&Arc::new(self.environment()), CycleStrategy::Tabling);
 
         // Create a vector of references to impl datums, sorted by trait ref
         let impl_data = self.impl_data.values().sorted_by(|lhs, rhs| {
@@ -80,7 +80,7 @@ fn intersection_of(lhs: &ImplDatum, rhs: &ImplDatum) -> InEnvironment<Goal> {
 
     let lhs_len = lhs.binders.len();
 
-    // Join the two impls' binders together 
+    // Join the two impls' binders together
     let mut binders = lhs.binders.binders.clone();
     binders.extend(rhs.binders.binders.clone());
 
@@ -100,7 +100,7 @@ fn intersection_of(lhs: &ImplDatum, rhs: &ImplDatum) -> InEnvironment<Goal> {
     // Create a goal for each clause in both where clauses
     let wc_goals = lhs_where_clauses.chain(rhs_where_clauses)
                 .map(|wc| Goal::Leaf(LeafGoal::DomainGoal(wc)));
- 
+
     // Join all the goals we've created together with And, then quantify them
     // over the joined binders. This is our query.
     let goal = params_goals.chain(wc_goals)

--- a/src/solve/test.rs
+++ b/src/solve/test.rs
@@ -228,8 +228,7 @@ fn ordering() {
 }
 
 #[test]
-fn cycles() {
-    // only solution: infinite type S<S<S<...
+fn cycle_no_solution() {
     test! {
         program {
             trait Foo { }
@@ -237,6 +236,7 @@ fn cycles() {
             impl<T> Foo for S<T> where T: Foo { }
         }
 
+        // only solution: infinite type S<S<S<...
         goal {
             exists<T> {
                 T: Foo
@@ -245,8 +245,10 @@ fn cycles() {
             "No possible solution: no applicable candidates"
         }
     }
+}
 
-    // infinite family of solutions: {i32, S<i32>, S<S<i32>>, ... }
+#[test]
+fn cycle_many_solutions() {
     test! {
         program {
             trait Foo { }
@@ -256,6 +258,7 @@ fn cycles() {
             impl Foo for i32 { }
         }
 
+        // infinite family of solutions: {i32, S<i32>, S<S<i32>>, ... }
         goal {
             exists<T> {
                 T: Foo
@@ -264,7 +267,10 @@ fn cycles() {
             "Ambiguous; no inference guidance"
         }
     }
+}
 
+#[test]
+fn cycle_unique_solution() {
     test! {
         program {
             trait Foo { }


### PR DESCRIPTION
These commits add a stack-based tabling approach for detecting and handling cycles (see #42). In case of multiple cycles the debug output can grow large so there is an option for deactivating this strategy and instead treat cycles as error (the solver will then produce "less" answers in some sense) which is useful for debugging. This PR will enable dealing with #12.