### PR TITLE
Elaborating where clauses directly in the logic

### DIFF
--- a/chalk-parse/src/ast.rs
+++ b/chalk-parse/src/ast.rs
@@ -162,7 +162,10 @@ pub struct Field {
 pub enum Goal {
     ForAll(Vec<ParameterKind>, Box<Goal>),
     Exists(Vec<ParameterKind>, Box<Goal>),
-    Implies(Vec<WhereClause>, Box<Goal>),
+
+    // The `bool` flag indicates whether we should elaborate where clauses or not
+    Implies(Vec<WhereClause>, Box<Goal>, bool),
+
     And(Box<Goal>, Box<Goal>),
     Not(Box<Goal>),
 

--- a/chalk-parse/src/parser.lalrpop
+++ b/chalk-parse/src/parser.lalrpop
@@ -28,10 +28,14 @@ pub Goal: Box<Goal> = {
 Goal1: Box<Goal> = {
     "forall" "<" <p:Comma<ParameterKind>> ">" "{" <g:Goal> "}" => Box::new(Goal::ForAll(p, g)),
     "exists" "<" <p:Comma<ParameterKind>> ">" "{" <g:Goal> "}" => Box::new(Goal::Exists(p, g)),
-    "if" "(" <w:Comma<WhereClause>> ")" "{" <g:Goal> "}" => Box::new(Goal::Implies(w, g, true)),
-    "if_raw" "(" <w:Comma<WhereClause>> ")" "{" <g:Goal> "}" => Box::new(Goal::Implies(w, g, false)),
+    <i:IfKeyword> "(" <w:Comma<WhereClause>> ")" "{" <g:Goal> "}" => Box::new(Goal::Implies(w, g, i)),
     "not" "{" <g:Goal> "}" => Box::new(Goal::Not(g)),
     <w:WhereClause> => Box::new(Goal::Leaf(w)),
+};
+
+IfKeyword: bool = {
+    "if" => true,
+    "if_raw" => false,
 };
 
 StructDefn: StructDefn = {

--- a/chalk-parse/src/parser.lalrpop
+++ b/chalk-parse/src/parser.lalrpop
@@ -28,7 +28,8 @@ pub Goal: Box<Goal> = {
 Goal1: Box<Goal> = {
     "forall" "<" <p:Comma<ParameterKind>> ">" "{" <g:Goal> "}" => Box::new(Goal::ForAll(p, g)),
     "exists" "<" <p:Comma<ParameterKind>> ">" "{" <g:Goal> "}" => Box::new(Goal::Exists(p, g)),
-    "if" "(" <w:Comma<WhereClause>> ")" "{" <g:Goal> "}" => Box::new(Goal::Implies(w, g)),
+    "if" "(" <w:Comma<WhereClause>> ")" "{" <g:Goal> "}" => Box::new(Goal::Implies(w, g, true)),
+    "if_raw" "(" <w:Comma<WhereClause>> ")" "{" <g:Goal> "}" => Box::new(Goal::Implies(w, g, false)),
     "not" "{" <g:Goal> "}" => Box::new(Goal::Not(g)),
     <w:WhereClause> => Box::new(Goal::Leaf(w)),
 };

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -225,6 +225,9 @@ pub struct AssociatedTyDatum {
     /// Parameters on this associated type, beginning with those from the trait,
     /// but possibly including more.
     pub parameter_kinds: Vec<ParameterKind<Identifier>>,
+
+    /// Where clauses that must hold for the projection be well-formed.
+    pub where_clauses: Vec<DomainGoal>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
@@ -367,7 +370,7 @@ impl DomainGoal {
     }
 
     /// A clause of the form (T: Foo) expands to (T: Foo), WF(T: Foo).
-    /// A clause of the form (T: Foo<Item = U>) expands to (T: Foo<Item = U>), (T: Foo), WF(T: Foo).
+    /// A clause of the form (T: Foo<Item = U>) expands to (T: Foo<Item = U>), WF(T: Foo).
     pub fn expanded(self, program: &Program) -> impl Iterator<Item = DomainGoal> {
         let mut expanded = vec![];
         match self {
@@ -380,7 +383,6 @@ impl DomainGoal {
                     trait_id: associated_ty_data.trait_id,
                     parameters: trait_params.to_owned()
                 };
-                expanded.push(trait_ref.clone().cast());
                 expanded.push(WellFormed::TraitRef(trait_ref).cast());
             }
             _ => ()

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -196,6 +196,7 @@ pub struct StructDatum {
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct StructDatumBound {
     pub self_ty: ApplicationTy,
+    pub fields: Vec<Ty>,
     pub where_clauses: Vec<DomainGoal>,
 }
 
@@ -224,9 +225,6 @@ pub struct AssociatedTyDatum {
     /// Parameters on this associated type, beginning with those from the trait,
     /// but possibly including more.
     pub parameter_kinds: Vec<ParameterKind<Identifier>>,
-
-    /// Where clauses that must hold for the projection be well-formed.
-    pub where_clauses: Vec<DomainGoal>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -368,6 +368,8 @@ impl DomainGoal {
         }
     }
 
+    /// A clause of the form (T: Foo) expands to (T: Foo), WF(T: Foo).
+    /// A clause of the form (T: Foo<Item = U>) expands to (T: Foo<Item = U>), (T: Foo), WF(T: Foo).
     pub fn expanded(self, program: &Program) -> impl Iterator<Item = DomainGoal> {
         let mut expanded = vec![];
         match self {

--- a/src/lower/mod.rs
+++ b/src/lower/mod.rs
@@ -918,13 +918,11 @@ impl ir::StructDatum {
     fn to_program_clauses(&self, program: &ir::Program) -> Vec<ir::ProgramClause> {
         // Given:
         //
-        //    struct Foo<T: Eq> {
-        //        field: Bar
-        //    }
+        //    struct Foo<T: Eq> { }
         //
         // we generate the following clause:
         //
-        //    for<?T> WF(Foo<?T>) :- WF(?T), WF(Bar), (?T: Eq), WF(?T: Eq).
+        //    for<?T> WF(Foo<?T>) :- WF(?T), (?T: Eq), WF(?T: Eq).
 
         let wf = ir::ProgramClause {
             implication: self.binders.map_ref(|bound_datum| {
@@ -939,17 +937,12 @@ impl ir::StructDatum {
                                              .cloned()
                                              .map(|ty| ir::WellFormed::Ty(ty).cast());
 
-                        let fields = bound_datum.fields
-                                                .iter()
-                                                .cloned()
-                                                .map(|ty| ir::WellFormed::Ty(ty).cast());
-
                         let where_clauses = bound_datum.where_clauses.iter()
                                                        .cloned()
                                                        .flat_map(|wc| wc.expanded(program))
                                                        .map(|wc| wc.cast());
 
-                        tys.chain(fields).chain(where_clauses).collect()
+                        tys.chain(where_clauses).collect()
                     }
                 }
             }),

--- a/src/lower/mod.rs
+++ b/src/lower/mod.rs
@@ -156,16 +156,8 @@ impl LowerProgram for Program {
                 Item::TraitDefn(ref d) => {
                     trait_data.insert(item_id, d.lower_trait(item_id, &empty_env)?);
 
-                    let trait_datum = &trait_data[&item_id];
                     for defn in &d.assoc_ty_defns {
                         let info = &associated_ty_infos[&(item_id, defn.name.str)];
-
-                        // `trait_ref` is the trait ref defined by
-                        // this impl, but shifted to account for the
-                        // add'l bindings that are in scope w/in the
-                        // assoc-ty-value.
-                        let offset = info.addl_parameter_kinds.len();
-                        let trait_ref = trait_datum.binders.value.trait_ref.up_shift(offset);
 
                         let mut parameter_kinds = defn.all_parameters();
                         parameter_kinds.extend(d.all_parameters());
@@ -175,7 +167,7 @@ impl LowerProgram for Program {
                             id: info.id,
                             name: defn.name.str,
                             parameter_kinds: parameter_kinds,
-                            where_clauses: vec![ir::DomainGoal::Implemented(trait_ref)]
+                            where_clauses: vec![]
                         });
                     }
                 }
@@ -390,8 +382,12 @@ impl LowerWhereClause<ir::DomainGoal> for WhereClause {
                     ty: ty.lower(env)?,
                 })
             }
-            WhereClause::TyWellFormed { .. } |
-            WhereClause::TraitRefWellFormed { .. } |
+            WhereClause::TyWellFormed { ref ty } => {
+                ir::WellFormed::Ty(ty.lower(env)?).cast()
+            }
+            WhereClause::TraitRefWellFormed { ref trait_ref } => {
+                ir::WellFormed::TraitRef(trait_ref.lower(env)?).cast()
+            }
             WhereClause::UnifyTys { .. } |
             WhereClause::UnifyLifetimes { .. } => {
                 bail!("this form of where-clause not allowed here")
@@ -774,12 +770,12 @@ impl ir::Program {
         //       forall P0...Pn. Something :- Conditions
         let mut program_clauses = vec![];
 
-        program_clauses.extend(self.struct_data.values().flat_map(|d| d.to_program_clauses()));
-        program_clauses.extend(self.trait_data.values().flat_map(|d| d.to_program_clauses()));
-        program_clauses.extend(self.associated_ty_data.values().flat_map(|d| d.to_program_clauses()));
+        program_clauses.extend(self.struct_data.values().flat_map(|d| d.to_program_clauses(self)));
+        program_clauses.extend(self.trait_data.values().flat_map(|d| d.to_program_clauses(self)));
+        program_clauses.extend(self.associated_ty_data.values().flat_map(|d| d.to_program_clauses(self)));
 
         for datum in self.impl_data.values() {
-            program_clauses.push(datum.to_program_clause());
+            program_clauses.push(datum.to_program_clause(self));
             program_clauses.extend(datum.binders.value.associated_ty_values.iter().flat_map(|atv| {
                 atv.to_program_clauses(datum)
             }));
@@ -798,12 +794,17 @@ impl ir::ImplDatum {
     /// ```notrust
     /// forall<T> { (Vec<T>: Clone) :- (T: Clone) }
     /// ```
-    fn to_program_clause(&self) -> ir::ProgramClause {
+    fn to_program_clause(&self, program: &ir::Program) -> ir::ProgramClause {
         ir::ProgramClause {
             implication: self.binders.map_ref(|bound| {
                 ir::ProgramClauseImplication {
                     consequence: bound.trait_ref.clone().cast(),
-                    conditions: bound.where_clauses.clone().cast(),
+                    conditions: bound.where_clauses
+                                     .iter()
+                                     .cloned()
+                                     .flat_map(|wc| wc.expanded(program))
+                                     .map(|wc| wc.cast())
+                                     .collect(),
                 }
             }),
             fallback_clause: false,
@@ -914,62 +915,31 @@ impl Anonymize for [ir::ParameterKind<ir::Identifier>] {
 }
 
 impl ir::StructDatum {
-    fn to_program_clauses(&self) -> Vec<ir::ProgramClause> {
+    fn to_program_clauses(&self, program: &ir::Program) -> Vec<ir::ProgramClause> {
         // Given:
         //
         //    struct Foo<T: Eq> { ... }
         //
         // we generate the following clause:
         //
-        //    for<?T> WF(Foo<?T>) :- (?T: Eq).
+        //    for<?T> WF(Foo<?T>) :- WF(?T), (?T: Eq), WF(?T: Eq).
 
         let wf = ir::ProgramClause {
             implication: self.binders.map_ref(|bound_datum| {
                 ir::ProgramClauseImplication {
                     consequence: ir::WellFormed::Ty(bound_datum.self_ty.clone().cast()).cast(),
 
-                    conditions: bound_datum.where_clauses.iter()
-                                                         .cloned()
-                                                         .map(|wc| wc.cast())
-                                                         .collect(),
-                }
-            }),
-            fallback_clause: false,
-        };
-
-        vec![wf]
-    }
-}
-
-impl ir::TraitDatum {
-    fn to_program_clauses(&self) -> Vec<ir::ProgramClause> {
-        // Given:
-        //
-        //    trait Ord<T> where Self: Eq<T> { ... }
-        //
-        // we generate the following clause:
-        //
-        //    for<?Self, ?T> WF(?Self: Ord<?T>) :-
-        //        // types are well-formed:
-        //        WF(?Self),
-        //        WF(?T),
-        //        // where clauses declared on the trait are met:
-        //        (?Self: Eq<?T>),
-
-        let wf = ir::ProgramClause {
-            implication: self.binders.map_ref(|bound| {
-                ir::ProgramClauseImplication {
-                    consequence: ir::WellFormed::TraitRef(bound.trait_ref.clone()).cast(),
-
                     conditions: {
-                        let tys = bound.trait_ref.parameters
-                                                 .iter()
-                                                 .filter_map(|pk| pk.as_ref().ty())
-                                                 .map(|ty| ir::WellFormed::Ty(ty.clone()).cast());
+                        let tys = bound_datum.self_ty
+                                             .parameters
+                                             .iter()
+                                             .filter_map(|pk| pk.as_ref().ty())
+                                             .map(|ty| ir::WellFormed::Ty(ty.clone()).cast());
 
-                        let where_clauses = bound.where_clauses.iter()
-                                                               .cloned()
-                                                               .map(|wc| wc.cast());
+                        let where_clauses = bound_datum.where_clauses.iter()
+                                                       .cloned()
+                                                       .flat_map(|wc| wc.expanded(program))
+                                                       .map(|wc| wc.cast());
 
                         tys.chain(where_clauses).collect()
                     }
@@ -982,8 +952,68 @@ impl ir::TraitDatum {
     }
 }
 
+impl ir::TraitDatum {
+    fn to_program_clauses(&self, program: &ir::Program) -> Vec<ir::ProgramClause> {
+        // Given:
+        //
+        //    trait Ord<T> where Self: Eq<T> { ... }
+        //
+        // we generate the following clauses:
+        //
+        //    for<?Self, ?T> WF(?Self: Ord<?T>) :-
+        //        // types are well-formed:
+        //        WF(?Self),
+        //        WF(?T),
+        //        // where clauses declared on the trait are met:
+        //        (?Self: Eq<?T>), WF(?Self: Eq<?T>)
+        //
+        //    for<?Self, ?T> (?Self: Eq<T>) :- WF(?Self: Ord<T>)
+        //    for<?Self, ?T> WF(?Self: Ord<?T>) :- WF(?Self: Ord<T>)
+
+        let where_clauses = self.binders.value.where_clauses
+            .iter()
+            .cloned()
+            .flat_map(|wc| wc.expanded(program))
+            .collect::<Vec<_>>();
+
+        let wf = ir::ProgramClause {
+            implication: self.binders.map_ref(|bound| {
+                ir::ProgramClauseImplication {
+                    consequence: ir::WellFormed::TraitRef(bound.trait_ref.clone()).cast(),
+
+                    conditions: {
+                        let tys = bound.trait_ref.parameters
+                                                 .iter()
+                                                 .filter_map(|pk| pk.as_ref().ty())
+                                                 .map(|ty| ir::WellFormed::Ty(ty.clone()).cast());
+
+                        tys.chain(where_clauses.iter().cloned().map(|wc| wc.cast())).collect()
+                    }
+                }
+            }),
+            fallback_clause: false,
+        };
+
+        let mut clauses = vec![wf];
+
+        for wc in where_clauses {
+            clauses.push(ir::ProgramClause {
+                implication: self.binders.map_ref(|bound| {
+                    ir::ProgramClauseImplication {
+                        consequence: wc,
+                        conditions: vec![ir::WellFormed::TraitRef(bound.trait_ref.clone()).cast()]
+                    }
+                }),
+                fallback_clause: false,
+            });
+        }
+
+        clauses
+    }
+}
+
 impl ir::AssociatedTyDatum {
-    fn to_program_clauses(&self) -> Vec<ir::ProgramClause> {
+    fn to_program_clauses(&self, program: &ir::Program) -> Vec<ir::ProgramClause> {
         // For each associated type, we define a normalization "fallback" for
         // projecting when we don't have constraints to say anything interesting
         // about an associated type.
@@ -996,13 +1026,22 @@ impl ir::AssociatedTyDatum {
         //
         // we generate:
         //
-        //    <?T as Foo>::Assoc ==> (Foo::Assoc)<?T>.
+        //    <?T as Foo>::Assoc ==> (Foo::Assoc)<?T> :- (?T: Foo)
+        //    forall<U> { (?T: Foo) :- <?T as Foo>::Assoc ==> U }
 
         let binders: Vec<_> = self.parameter_kinds.iter().map(|pk| pk.map(|_| ())).collect();
         let parameters: Vec<_> = binders.iter().zip(0..).map(|p| p.to_parameter()).collect();
         let projection = ir::ProjectionTy {
             associated_ty_id: self.id,
             parameters: parameters.clone(),
+        };
+
+        let trait_ref = {
+            let (associated_ty_data, trait_params, _) = program.split_projection(&projection);
+            ir::TraitRef {
+                trait_id: associated_ty_data.trait_id,
+                parameters: trait_params.to_owned()
+            }
         };
 
         let fallback = {
@@ -1013,17 +1052,48 @@ impl ir::AssociatedTyDatum {
 
             ir::ProgramClause {
                 implication: ir::Binders {
-                    binders,
+                    binders: binders.clone(),
                     value: ir::ProgramClauseImplication {
                         consequence: ir::Normalize { projection: projection.clone(), ty }.cast(),
-                        // TODO: should probably include the TraitRef here
-                        conditions: vec![],
+                        conditions: self.where_clauses
+                                        .iter()
+                                        .cloned()
+                                        .flat_map(|wc| wc.expanded(program))
+                                        .map(|wc| wc.cast())
+                                        .chain(Some(trait_ref.clone().cast()))
+                                        .collect()
                     }
                 },
                 fallback_clause: true,
             }
         };
 
-        vec![fallback]
+        let elaborate = {
+            let trait_ref = {
+                let (associated_ty_data, trait_params, _) = program.split_projection(&projection);
+                ir::TraitRef {
+                    trait_id: associated_ty_data.trait_id,
+                    parameters: trait_params.to_owned()
+                }
+            };
+
+            // add new type parameter U
+            let mut binders = binders;
+            binders.push(ir::ParameterKind::Ty(()));
+            let ty = ir::Ty::Var(binders.len() - 1);
+
+            ir::ProgramClause {
+                implication: ir::Binders {
+                    binders,
+                    value: ir::ProgramClauseImplication {
+                        consequence: trait_ref.cast(),
+                        conditions: vec![ir::Normalize { projection, ty }.cast()],
+                    }
+                },
+                fallback_clause: false,
+            }
+        };
+
+        vec![fallback, elaborate]
     }
 }

--- a/src/solve/solver.rs
+++ b/src/solve/solver.rs
@@ -144,9 +144,8 @@ impl Solver {
                     // or from the lowered program, which includes fallback
                     // clauses. We try each approach in turn:
 
-                    let env_clauses = value
-                        .environment
-                        .elaborated_clauses(&self.program)
+                    let env_clauses = value.environment.clauses.iter()
+                        .cloned()
                         .map(DomainGoal::into_program_clause);
                     let env_solution = self.solve_from_clauses(&binders, &value, env_clauses);
 

--- a/src/solve/test.rs
+++ b/src/solve/test.rs
@@ -701,47 +701,6 @@ fn struct_wf() {
 }
 
 #[test]
-fn struct_with_fields_wf() {
-    test! {
-        program {
-            struct Foo { }
-
-            struct Bar {
-                f: Foo
-            }
-
-            trait Clone { }
-            struct Dummy<T> where T: Clone { }
-            impl Clone for Foo { }
-
-            struct Baz<T> {
-                f: Dummy<T>
-            }
-        }
-
-        goal {
-            WellFormed(Bar)
-        } yields {
-            "Unique"
-        }
-
-        // `Bar` does not implement `Clone` so `Dummy<Bar>` is ill-formed
-        goal {
-            WellFormed(Baz<Bar>)
-        } yields {
-            "No possible solution"
-        }
-
-        // This time `Foo` does implement `Clone`
-        goal {
-            WellFormed(Baz<Foo>)
-        } yields {
-            "Unique"
-        }
-    }
-}
-
-#[test]
 fn generic_trait() {
     test! {
         program {

--- a/src/solve/test.rs
+++ b/src/solve/test.rs
@@ -175,12 +175,22 @@ fn prove_forall() {
         // Here, we do know that `T: Clone`, so we can.
         goal {
             forall<T> {
-                if (WellFormed(T: Clone), T: Clone) {
+                if (T: Clone) {
                     Vec<T>: Clone
                 }
             }
         } yields {
             "Unique; substitution [], lifetime constraints []"
+        }
+
+        goal {
+            forall<T> {
+                if_raw (T: Clone) {
+                    Vec<T>: Clone
+                }
+            }
+        } yields {
+            "CannotProve"
         }
     }
 }
@@ -546,7 +556,7 @@ fn elaborate_eq() {
 
         goal {
             forall<T> {
-                if (WellFormed(T: Eq)) {
+                if (T: Eq) {
                     T: PartialEq
                 }
             }
@@ -567,7 +577,7 @@ fn elaborate_transitive() {
 
         goal {
             forall<T> {
-                if (WellFormed(T: StrictEq)) {
+                if (T: StrictEq) {
                     T: PartialEq
                 }
             }
@@ -596,7 +606,7 @@ fn elaborate_normalize() {
 
         goal {
             forall<T, U> {
-                if (WellFormed(T: Item), T: Item<Out = U>) {
+                if (T: Item<Out = U>) {
                     U: Eq
                 }
             }
@@ -753,6 +763,8 @@ fn trait_wf() {
 
             impl Ord<Int> for Int { }
             impl<T> Ord<Vec<T>> for Vec<T> where T: Ord<T> { }
+
+            impl<T> Ord<Slice<T>> for Slice<T> { }
         }
 
         goal {
@@ -780,12 +792,18 @@ fn trait_wf() {
         }
 
         goal {
+            Slice<Int>: Ord<Slice<Int>>
+        } yields {
+            "Unique"
+        }
+
+        goal {
             Slice<Int>: Eq<Slice<Int>>
         } yields {
             "No possible solution"
         }
 
-        // not WF because previous equation doesn't hold
+        // not WF because previous equation doesn't hold, despite Slice<Int> having an impl for Ord<Int> 
         goal {
             WellFormed(Slice<Int>: Ord<Slice<Int>>)
         } yields {

--- a/src/solve/test.rs
+++ b/src/solve/test.rs
@@ -613,6 +613,16 @@ fn elaborate_normalize() {
         } yields {
             "Unique"
         }
+
+        goal {
+            forall<T> {
+                if (T: Item<Out = i32>) {
+                    T: Item
+                }
+            }
+        } yields {
+            "Unique"
+        }
     }
 }
 
@@ -686,6 +696,47 @@ fn struct_wf() {
             WellFormed(Foo<Foo<Baz>>)
         } yields {
             "Unique; substitution [], lifetime constraints []"
+        }
+    }
+}
+
+#[test]
+fn struct_with_fields_wf() {
+    test! {
+        program {
+            struct Foo { }
+
+            struct Bar {
+                f: Foo
+            }
+
+            trait Clone { }
+            struct Dummy<T> where T: Clone { }
+            impl Clone for Foo { }
+
+            struct Baz<T> {
+                f: Dummy<T>
+            }
+        }
+
+        goal {
+            WellFormed(Bar)
+        } yields {
+            "Unique"
+        }
+
+        // `Bar` does not implement `Clone` so `Dummy<Bar>` is ill-formed
+        goal {
+            WellFormed(Baz<Bar>)
+        } yields {
+            "No possible solution"
+        }
+
+        // This time `Foo` does implement `Clone`
+        goal {
+            WellFormed(Baz<Foo>)
+        } yields {
+            "Unique"
         }
     }
 }

--- a/src/solve/test.rs
+++ b/src/solve/test.rs
@@ -183,6 +183,8 @@ fn prove_forall() {
             "Unique; substitution [], lifetime constraints []"
         }
 
+        // This fails because we used `if_raw`, and hence we do not
+        // know that `WF(T: Clone)` holds.
         goal {
             forall<T> {
                 if_raw (T: Clone) {


### PR DESCRIPTION
These commits aim at implementing the additional rules described in #12 for elaborating where clauses
directly in the logic. Basically, each where clause of the form `T: Foo` expands to `T: Foo, WF(T: Foo)`
and each where clause of the form `T: Foo<Item = U>` expands to `T: Foo<Item = U>, T: Foo, WF(T: Foo)`.
We also added reverse rules on traits and associated types, and well-formedness checking of struct
parameters and fields.

Also, the `where_clauses` field on `AssociatedTyDatum` was removed since this can be emulated by writing:
```rust
trait Item where <Self as Item>::Out: Eq {
    type Out;
}
```

## Traits
The rules generated by a trait declaration are:
```rust
trait Bar { }
// WF(?Self: Bar) :- WF(?Self)

trait Foo<T> where T: Bar { }
// WF(?Self: Foo<?T>) :- WF(?Self), WF(?T), (?T: Bar), WF(?T: Bar)

// "Reverse" rules
// (?T: Bar) :- WF(?Self: Foo<?T>)
// WF(?T: Bar) :- WF(?Self: Foo<?T>)
```

## Structs
The rules generated by a struct declaration are:
```rust
trait Clone { }
struct Bar { }

struct Foo<T, U> where T: Clone { }
// WF(Foo<?T, ?U>) :- WF(?T), (T: Clone), WF(?T: Clone)
```

## Impls
The rules generated by an impl declaration are:
```rust
trait Clone { }
trait Foo<T> { }
struct X { }

impl Foo<T> for X where T: Clone { }
// (X: Foo<?T>) :- (?T: Clone), WF(?T: Clone)
// no need to check WF(?T) because this will be required by WF(X: Foo<?T>)
```

## Associated types
The rules generated by an associated type definition are:
```rust
trait Foo {
    type Assoc;
}
// <?T as Foo>::Assoc ==> (Foo::Assoc)<?T> :- (?T: Foo)
// forall<U> { (?T: Foo) :- <?T as Foo>::Assoc ==> U }
```
