### PR TITLE
remove `cannot_prove` from unify, change approach to universals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,7 +2,7 @@
 name = "chalk-parse"
 version = "0.1.0"
 dependencies = [
- "error-chain 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lalrpop 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lalrpop-intern 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lalrpop-util 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -87,7 +87,7 @@ version = "0.1.0"
 dependencies = [
  "chalk-parse 0.1.0",
  "ena 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "error-chain 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lalrpop-intern 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -142,7 +142,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "error-chain"
-version = "0.7.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "backtrace 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -406,7 +406,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum ena 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5c109645f12ca057044ef2ffa56670cf7e3fd1fa530d73cd185e8298b03380b5"
 "checksum ena 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cabe5a5078ac8c506d3e4430763b1ba9b609b1286913e7d08e581d1c2de9b7e5"
 "checksum encode_unicode 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "28d65f1f5841ef7c6792861294b72beda34c664deb8be27970f36c306b7da1ce"
-"checksum error-chain 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "318cb3c71ee4cdea69fdc9e15c173b245ed6063e1709029e8fd32525a881120f"
+"checksum error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff511d5dc435d703f4971bc399647c9bc38e20cb41452e3b9feb4765419ed3f3"
 "checksum fixedbitset 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "fcf4412e2d11115c5ed81c2fbdaba8028de0c92553497aa771fc5f4e0c5c8793"
 "checksum gcc 0.3.51 (registry+https://github.com/rust-lang/crates.io-index)" = "120d07f202dcc3f72859422563522b66fe6463a4c513df062874daad05f85f0a"
 "checksum itertools 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4833d6978da405305126af4ac88569b5d71ff758581ce5a987dbfa3755f694fc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 
 [dependencies]
 ena = "0.4"
-error-chain = "0.7.2"
+error-chain = "0.11.0"
 itertools = "0.6.0"
 lalrpop-intern = "0.13.1"
 lazy_static = "0.2.2"

--- a/chalk-parse/Cargo.toml
+++ b/chalk-parse/Cargo.toml
@@ -12,6 +12,6 @@ version = "0.13.1"
 version = "0.13.1"
 
 [dependencies]
-error-chain = "0.7.2"
+error-chain = "0.11.0"
 lalrpop-intern = "0.13.1"
 regex = "0.2.2"

--- a/src/coherence/solve.rs
+++ b/src/coherence/solve.rs
@@ -118,7 +118,10 @@ impl Solver {
                     .expect("Every trait takes at least one input type")
                     .quantify(QuantifierKind::Exists, binders);
 
-        self.solve_closed_goal(InEnvironment::empty(goal)).ok().map_or(false, |sol| !sol.cannot_be_proven())
+        self.solve_closed_goal(InEnvironment::empty(goal))
+            .ok()
+            .map(|sol| sol.has_definite())
+            .unwrap_or(false)
     }
 
     // Test for specialization.

--- a/src/fold/instantiate.rs
+++ b/src/fold/instantiate.rs
@@ -39,8 +39,8 @@ macro_rules! subst_method {
 subst_method!(Goal);
 subst_method!(Ty);
 
-impl<'b> FolderVar for Subst<'b> {
-    fn fold_free_var(&mut self, depth: usize, binders: usize) -> Result<Ty> {
+impl<'b> ExistentialFolder for Subst<'b> {
+    fn fold_free_existential_ty(&mut self, depth: usize, binders: usize) -> Result<Ty> {
         if depth >= self.parameters.len() {
             Ok(Ty::Var(depth - self.parameters.len() + binders))
         } else {
@@ -51,7 +51,7 @@ impl<'b> FolderVar for Subst<'b> {
         }
     }
 
-    fn fold_free_lifetime_var(&mut self, depth: usize, binders: usize) -> Result<Lifetime> {
+    fn fold_free_existential_lifetime(&mut self, depth: usize, binders: usize) -> Result<Lifetime> {
         if depth >= self.parameters.len() {
             Ok(Lifetime::Var(depth - self.parameters.len() + binders))
         } else {
@@ -61,4 +61,7 @@ impl<'b> FolderVar for Subst<'b> {
             }
         }
     }
+}
+
+impl<'b> IdentityUniversalFolder for Subst<'b> {
 }

--- a/src/fold/shifted.rs
+++ b/src/fold/shifted.rs
@@ -1,5 +1,6 @@
 use errors::*;
-use super::{Fold, Folder, FolderRef, Shifter};
+use fold::{Fold, Folder};
+use fold::shifter::Shifter;
 
 /// Sometimes we wish to fold two values with a distinct deBruijn
 /// depth (i.e., you want to fold `(A, B)` where A is defined under N
@@ -19,8 +20,8 @@ impl<T: Fold> Shifted<T> {
     }
 }
 
-impl<T: Fold> Fold for Shifted<T> {
-    type Result = T::Result;
+impl<T: Fold<Result = T>> Fold for Shifted<T> {
+    type Result = T;
 
     fn fold_with(&self, folder: &mut Folder, binders: usize) -> Result<Self::Result> {
         // I... think this is right if binders is not zero, but not sure,
@@ -31,8 +32,8 @@ impl<T: Fold> Fold for Shifted<T> {
         // contains a free var with index 0, and `self.adjustment ==
         // 2`, we will translate it to a free var with index 2; then
         // we will fold *that* through `folder`.
-        let mut new_folder = (Shifter::new(self.adjustment), FolderRef::new(folder));
-        self.value.fold_with(&mut new_folder, binders)
+        let value = self.value.fold_with(&mut Shifter::new(self.adjustment), 0)?;
+        value.fold_with(folder, binders)
     }
 }
 

--- a/src/fold/shifter.rs
+++ b/src/fold/shifter.rs
@@ -1,6 +1,6 @@
 use errors::*;
 use ir::*;
-use super::{Fold, FolderVar};
+use super::{Fold, ExistentialFolder, IdentityUniversalFolder};
 
 pub struct Shifter {
     adjustment: usize
@@ -37,12 +37,14 @@ up_shift_method!(TraitRef);
 up_shift_method!(ProjectionTy);
 up_shift_method!(DomainGoal);
 
-impl FolderVar for Shifter {
-    fn fold_free_var(&mut self, depth: usize, binders: usize) -> Result<Ty> {
+impl ExistentialFolder for Shifter {
+    fn fold_free_existential_ty(&mut self, depth: usize, binders: usize) -> Result<Ty> {
         Ok(Ty::Var(depth + self.adjustment + binders))
     }
 
-    fn fold_free_lifetime_var(&mut self, depth: usize, binders: usize) -> Result<Lifetime> {
+    fn fold_free_existential_lifetime(&mut self, depth: usize, binders: usize) -> Result<Lifetime> {
         Ok(Lifetime::Var(depth + self.adjustment + binders))
     }
 }
+
+impl IdentityUniversalFolder for Shifter { }

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -164,6 +164,10 @@ impl UniverseIndex {
         self.counter >= ui.counter
     }
 
+    pub fn is_root(self) -> bool {
+        self.counter == 0
+    }
+
     pub fn to_lifetime(self) -> Lifetime {
         Lifetime::ForAll(self)
     }

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -144,6 +144,10 @@ impl TypeName {
             _ => false,
         }
     }
+
+    pub fn to_ty(self) -> Ty {
+        Ty::Apply(ApplicationTy { name: self, parameters: vec![] })
+    }
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -158,6 +162,10 @@ impl UniverseIndex {
 
     pub fn can_see(self, ui: UniverseIndex) -> bool {
         self.counter >= ui.counter
+    }
+
+    pub fn to_lifetime(self) -> Lifetime {
+        Lifetime::ForAll(self)
     }
 }
 

--- a/src/solve/infer/instantiate.rs
+++ b/src/solve/infer/instantiate.rs
@@ -44,8 +44,8 @@ struct Instantiator {
 /// `self.vars[i]`. Everything else stays intact, but we have to
 /// subtract `self.vars.len()` to account for the binders we are
 /// instantiating.
-impl FolderVar for Instantiator {
-    fn fold_free_var(&mut self, depth: usize, binders: usize) -> Result<Ty> {
+impl ExistentialFolder for Instantiator {
+    fn fold_free_existential_ty(&mut self, depth: usize, binders: usize) -> Result<Ty> {
         if depth < self.vars.len() {
             Ok(self.vars[depth].as_ref().ty().unwrap().to_ty().up_shift(binders))
         } else {
@@ -53,7 +53,7 @@ impl FolderVar for Instantiator {
         }
     }
 
-    fn fold_free_lifetime_var(&mut self, depth: usize, binders: usize) -> Result<Lifetime> {
+    fn fold_free_existential_lifetime(&mut self, depth: usize, binders: usize) -> Result<Lifetime> {
         if depth < self.vars.len() {
             Ok(self.vars[depth].as_ref().lifetime().unwrap().to_lifetime().up_shift(binders))
         } else {
@@ -61,3 +61,5 @@ impl FolderVar for Instantiator {
         }
     }
 }
+
+impl IdentityUniversalFolder for Instantiator { }

--- a/src/solve/infer/mod.rs
+++ b/src/solve/infer/mod.rs
@@ -4,6 +4,7 @@ use ir::*;
 
 mod instantiate;
 mod canonicalize;
+mod negate;
 mod unify;
 mod var;
 #[cfg(test)] mod test;

--- a/src/solve/infer/negate.rs
+++ b/src/solve/infer/negate.rs
@@ -1,0 +1,141 @@
+use errors::*;
+use fold::{Fold, ExistentialFolder, UniversalFolder};
+use ir::*;
+use std::collections::HashMap;
+
+use super::{InferenceTable, TyInferenceVariable, LifetimeInferenceVariable};
+use super::canonicalize::Canonicalized;
+
+impl InferenceTable {
+    /// Converts `value` into a "negation" value -- meaning one that,
+    /// if we can find any answer to it, then the negation fails. For
+    /// goals that do not contain any free variables, then this is a
+    /// no-op operation.
+    ///
+    /// If `value` contains any existential variables that have not
+    /// yet been assigned a value, then this function will return
+    /// `None`, indicating that we cannot prove negation for this goal
+    /// yet.  This follows the approach in Clark's original
+    /// negation-as-failure paper [1], where negative goals are only
+    /// permitted if they contain no free (existential) variables.
+    ///
+    /// [1] http://www.doc.ic.ac.uk/~klc/NegAsFailure.pdf
+    ///
+    /// Restricting free existential variables is done because the
+    /// semantics of such queries is not what you expect: it basically
+    /// treats the existential as a universal. For example, consider:
+    ///
+    /// ```rust,ignore
+    /// struct Vec<T> {}
+    /// struct i32 {}
+    /// struct u32 {}
+    /// trait Foo {}
+    /// impl Foo for Vec<u32> {}
+    /// ```
+    ///
+    /// If we ask `exists<T> { not { Vec<T>: Foo } }`, what should happen?
+    /// If we allow negative queries to be definitively answered even when
+    /// they contain free variables, we will get a definitive *no* to the
+    /// entire goal! From a logical perspective, that's just wrong: there
+    /// does exists a `T` such that `not { Vec<T>: Foo }`, namely `i32`. The
+    /// problem is that the proof search procedure is actually trying to
+    /// prove something stronger, that there is *no* such `T`.
+    ///
+    /// An additional complication arises around free universal
+    /// variables.  Consider a query like `not { !0 = !1 }`, where
+    /// `!0` and `!1` represent universally quantified types (i.e.,
+    /// `TypeName::ForAll`). If we just tried to prove `!0 = !1`, we
+    /// would get false, because those types cannot be unified -- this
+    /// would then allow us to conclude that `not { !0 = !1 }`, i.e.,
+    /// `forall<X, Y> { not { X = Y } }`, but this is clearly not true
+    /// -- what if X were to be equal to Y?
+    ///
+    /// Interestingly, the semantics of existential variables turns
+    /// out to be exactly what we want here. So, in addition to
+    /// forbidding existential variables in the original query, the
+    /// `negated` query also converts all universals *into*
+    /// existentials. Hence `negated` applies to `!0 = !1` would yield
+    /// `exists<X,Y> { X = Y }` (note that a canonical, i.e. closed,
+    /// result is returned). Naturally this has a solution, and hence `not { !0 = !1 }` fails,
+    /// as we expect.
+    ///
+    /// (One could imagine converting free existentials into
+    /// universals, rather than forbidding them altogether. This would
+    /// be conveivable, but overly strict. For example, the goal
+    /// `exists<T> { not { ?T: Clone }, ?T = Vec<i32> }` would come
+    /// back as false, when clearly this is true. This is because we
+    /// would wind up proving that `?T: Clone` can *never* be
+    /// satisfied (which is false), when we only really care about
+    /// `?T: Clone` in the case where `?T = Vec<i32>`. The current
+    /// version would delay processing the negative goal (i.e., return
+    /// `None`) until the second unification has occurred.)
+    pub fn negated<T>(&mut self, value: &T) -> Option<Canonical<T::Result>>
+        where T: Fold<Result = T>
+    {
+        let Canonicalized {
+            free_vars,
+            max_universe: _,
+            quantified,
+        } = self.canonicalize(&value);
+
+        // If the original contains free existential variables, give up.
+        if !free_vars.is_empty() {
+            return None;
+        }
+
+        // If this contains free universal variables, replace them with existentials.
+        assert!(quantified.binders.is_empty());
+        let inverted = {
+            let snapshot = self.snapshot();
+            let inverted = quantified.value.fold_with(&mut Inverter::new(self), 0).unwrap();
+            let inverted = self.canonicalize(&inverted);
+            assert!(inverted.max_universe.is_root());
+            self.rollback_to(snapshot);
+            inverted.quantified
+        };
+
+        Some(inverted)
+    }
+}
+
+struct Inverter<'q> {
+    table: &'q mut InferenceTable,
+    inverted_ty: HashMap<UniverseIndex, TyInferenceVariable>,
+    inverted_lifetime: HashMap<UniverseIndex, LifetimeInferenceVariable>,
+}
+
+impl<'q> Inverter<'q> {
+    fn new(table: &'q mut InferenceTable) -> Self {
+        Inverter { table, inverted_ty: HashMap::new(), inverted_lifetime: HashMap::new() }
+    }
+}
+
+impl<'q> UniversalFolder for Inverter<'q> {
+    fn fold_free_universal_ty(&mut self, universe: UniverseIndex, binders: usize) -> Result<Ty> {
+        let table = &mut self.table;
+        Ok(self.inverted_ty
+           .entry(universe)
+           .or_insert_with(|| table.new_variable(universe))
+           .to_ty()
+           .up_shift(binders))
+    }
+
+    fn fold_free_universal_lifetime(&mut self, universe: UniverseIndex, binders: usize) -> Result<Lifetime> {
+        let table = &mut self.table;
+        Ok(self.inverted_lifetime
+           .entry(universe)
+           .or_insert_with(|| table.new_lifetime_variable(universe))
+           .to_lifetime()
+           .up_shift(binders))
+    }
+}
+
+impl<'q> ExistentialFolder for Inverter<'q> {
+    fn fold_free_existential_ty(&mut self, _depth: usize, _binders: usize) -> Result<Ty> {
+        panic!("should not be any existentials")
+    }
+
+    fn fold_free_existential_lifetime(&mut self, _depth: usize, _binders: usize) -> Result<Lifetime> {
+        panic!("should not be any existentials")
+    }
+}

--- a/src/solve/infer/test.rs
+++ b/src/solve/infer/test.rs
@@ -52,8 +52,8 @@ struct Normalizer<'a> {
     table: &'a mut InferenceTable,
 }
 
-impl<'q> FolderVar for Normalizer<'q> {
-    fn fold_free_var(&mut self, depth: usize, binders: usize) -> Result<Ty> {
+impl<'q> ExistentialFolder for Normalizer<'q> {
+    fn fold_free_existential_ty(&mut self, depth: usize, binders: usize) -> Result<Ty> {
         assert_eq!(binders, 0);
         let var = TyInferenceVariable::from_depth(depth);
         match self.table.probe_var(var) {
@@ -62,10 +62,13 @@ impl<'q> FolderVar for Normalizer<'q> {
         }
     }
 
-    fn fold_free_lifetime_var(&mut self, depth: usize, binders: usize) -> Result<Lifetime> {
+    fn fold_free_existential_lifetime(&mut self, depth: usize, binders: usize) -> Result<Lifetime> {
         assert_eq!(binders, 0);
         Ok(LifetimeInferenceVariable::from_depth(depth).to_lifetime())
     }
+}
+
+impl<'q> IdentityUniversalFolder for Normalizer<'q> {
 }
 
 #[test]
@@ -95,7 +98,7 @@ fn cycle_error() {
     let mut table = InferenceTable::new();
     let environment0 = Environment::new();
     let a = table.new_variable(environment0.universe).to_ty();
-    table.unify(&environment0, &a, &ty!(apply (skol 1) (expr a))).unwrap_err();
+    table.unify(&environment0, &a, &ty!(apply (item 0) (expr a))).unwrap_err();
 }
 
 #[test]

--- a/src/solve/infer/test.rs
+++ b/src/solve/infer/test.rs
@@ -29,19 +29,6 @@ macro_rules! ty {
     };
 }
 
-macro_rules! trait_ref {
-    ((item $n:tt) $($arg:tt)*) => {
-        TraitRef {
-            trait_id: ItemId { index: $n },
-            parameters: vec![$(arg!($arg)),*],
-        }
-    };
-
-    (($($b:tt)*)) => {
-        trait_ref!($($b)*)
-    };
-}
-
 macro_rules! arg {
     ($arg:tt) => {
         ParameterKind::Ty(ty!($arg))

--- a/src/solve/mod.rs
+++ b/src/solve/mod.rs
@@ -21,11 +21,6 @@ pub enum Solution {
     /// constraints, since we have not "committed" to any particular solution
     /// yet.
     Ambig(Guidance),
-
-    /// There is no instantiation of the existentials for which we could prove this goal
-    /// to be true. Nonetheless, the goal may yet be true for some instantiations of the
-    /// universals. In other words, this goal is neither true nor false.
-    CannotProve,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -71,8 +66,6 @@ impl Solution {
         use self::Guidance::*;
 
         if self == other { return self }
-        if other.cannot_be_proven() { return self }
-        if self.cannot_be_proven() { return other }
 
         // Otherwise, always downgrade to Ambig:
 
@@ -98,8 +91,6 @@ impl Solution {
         use self::Guidance::*;
 
         if self == other { return self }
-        if other.cannot_be_proven() { return self }
-        if self.cannot_be_proven() { return other }
 
         // Otherwise, always downgrade to Ambig:
 
@@ -118,8 +109,6 @@ impl Solution {
         use self::Guidance::*;
 
         if self == other { return self }
-        if other.cannot_be_proven() { return self }
-        if self.cannot_be_proven() { return other }
 
         if let Solution::Ambig(guidance) = self {
             match guidance {
@@ -141,7 +130,6 @@ impl Solution {
                 })
             }
             Solution::Ambig(guidance) => guidance,
-            Solution::CannotProve => Guidance::Unknown,
         }
     }
 
@@ -157,7 +145,7 @@ impl Solution {
                 };
                 Some(Canonical { value, binders: canonical.binders.clone() })
             }
-            Solution::Ambig(_) | Solution::CannotProve => None,
+            Solution::Ambig(_) => None,
         }
     }
 
@@ -174,13 +162,6 @@ impl Solution {
     pub fn is_ambig(&self) -> bool {
         match *self {
             Solution::Ambig(_) => true,
-            _ => false,
-        }
-    }
-
-    pub fn cannot_be_proven(&self) -> bool {
-        match *self {
-            Solution::CannotProve => true,
             _ => false,
         }
     }
@@ -209,9 +190,6 @@ impl fmt::Display for Solution {
             }
             Solution::Ambig(Guidance::Unknown) => {
                 write!(f, "Ambiguous; no inference guidance")
-            }
-            Solution::CannotProve => {
-                write!(f, "CannotProve")
             }
         }
     }

--- a/src/solve/solver.rs
+++ b/src/solve/solver.rs
@@ -119,6 +119,37 @@ impl Solver {
         fulfill.solve(subst)
     }
 
+    /// This ought to be the *True* entry point.
+    pub fn solve_canonical_goal(&mut self,
+                                canonical_goal: &Canonical<InEnvironment<Goal>>)
+                                -> Result<Solution> {
+        let mut fulfill = Fulfill::new(self);
+
+        let goal = fulfill.instantiate(canonical_goal.binders.iter().cloned(),
+                                       &canonical_goal.value);
+
+        // We use this somewhat hacky approach to get our hands on the
+        // instantiated variables after instantiating the canonical
+        // goal. This substitution is only used for REPL/debugging
+        // purposes anyway; in rustc, the top-level interaction would
+        // happen by manipulating a Fulfill more directly.
+        let subst = Substitution {
+            tys: fulfill
+                .ty_vars()
+                .iter()
+                .map(|t| (*t, t.to_ty()))
+                .collect(),
+            lifetimes: fulfill
+                .lifetime_vars()
+                .iter()
+                .map(|lt| (*lt, lt.to_lifetime()))
+                .collect(),
+        };
+
+        fulfill.push_goal(&goal.environment, goal.goal);
+        fulfill.solve(subst)
+    }
+
     /// Attempt to solve a goal that has been fully broken down into leaf form
     /// and canonicalized. This is where the action really happens, and is the
     /// place where we would perform caching in rustc (and may eventually do in Chalk).

--- a/src/solve/test.rs
+++ b/src/solve/test.rs
@@ -140,13 +140,19 @@ fn prove_forall() {
         goal {
             forall<T> { T: Marker }
         } yields {
-            "CannotProve"
+            "No possible solution"
         }
 
         goal {
             forall<T> { not { T: Marker } }
         } yields {
-            "CannotProve"
+            "No"
+        }
+
+        goal {
+            not { forall<T> { T: Marker } }
+        } yields {
+            "Unique"
         }
 
         // If we assume `T: Marker`, then obviously `T: Marker`.
@@ -169,7 +175,7 @@ fn prove_forall() {
         goal {
             forall<T> { Vec<T>: Clone }
         } yields {
-            "CannotProve"
+            "No possible solution"
         }
 
         // Here, we do know that `T: Clone`, so we can.
@@ -192,7 +198,7 @@ fn prove_forall() {
                 }
             }
         } yields {
-            "CannotProve"
+            "No possible solution"
         }
     }
 }
@@ -1283,6 +1289,14 @@ fn simple_negation() {
         } yields {
             "Unique"
         }
+
+        goal {
+            not {
+                forall<T> { T: Foo }
+            }
+        } yields {
+            "Unique"
+        }
     }
 }
 
@@ -1330,7 +1344,7 @@ fn negation_quantifiers() {
                 }
             }
         } yields {
-            "CannotProve"
+            "Unique"
         }
 
         goal {
@@ -1350,7 +1364,7 @@ fn negation_quantifiers() {
                 }
             }
         } yields {
-            "CannotProve"
+            "No"
         }
     }
 }
@@ -1509,7 +1523,7 @@ fn auto_trait_with_impls() {
                 Vec<T>: Send
             }
         } yields {
-            "CannotProve"
+            "No possible solution"
         }
     }
 }
@@ -1536,7 +1550,7 @@ fn coinductive_semantics() {
                 List<T>: Send
             }
         } yields {
-            "CannotProve"
+            "No possible solution"
         }
 
         // `WellFormed(T)` because of the hand-written impl for `Ptr<T>`.


### PR DESCRIPTION
Currently unification does not reject `i32 = T` (where `T` is a universally quantified variable). This leads to a fair amount of complexity, since we must now distinguish another kind of solution ("cannot prove") which is "similar but different" to ambiguity.

This commit removes all of that logic in favor of introducing a refined concept of the "must be ground" conditions from the negation-as-failure paper. In particular, the original paper noted that free inference variables wind up acting as universal constraints when negated -- which is exactly what we want here. So we introduce a new function `negated` that transforms a goal G by (a) forbidding free existential variables and (b) converting free universal variables into existential ones. If the resulting query G' is satisfiable, then `not { G }` is false.

cc @scalexm 